### PR TITLE
improve TableStore connector

### DIFF
--- a/docs/Hive-SparkSQL-on-TableStore.md
+++ b/docs/Hive-SparkSQL-on-TableStore.md
@@ -41,6 +41,8 @@ We have to create an external table in Hive/SparkSQL to let them known the exist
 CREATE EXTERNAL TABLE pet
   (name STRING, owner STRING, species STRING, sex STRING, birth STRING, death STRING)
   STORED BY 'com.aliyun.openservices.tablestore.hive.TableStoreStorageHandler'
+  WITH SERDEPROPERTIES(
+    "tablestore.columns.mapping"="name,owner,species,sex,birth,death")
   TBLPROPERTIES (
     "tablestore.endpoint"="YourEndpoint",
     "tablestore.access_key_id"="YourAccessKeyId",
@@ -74,9 +76,9 @@ Whistler        Gwen    bird    NULL    1997-12-09      NULL
 * `WITH SERDEPROPERTIES`
   + `tablestore.columns.mapping` (optional)
 
-    By default, field names of external tables are the same as column names (names of primary key columns or attributes) in TableStore.
+    By default, field names of external tables (in lower case by rules of Hive) are the same as column names (names of primary key columns or attributes) in TableStore.
     Sometimes, we need them to be different (for examples, dealing with case-sensitivity or charsets).
-    We can then set `tablestore.columns.mapping`, which is a comma-separated string, each item is a column name.
+    We can then set `tablestore.columns.mapping`, which is a comma-separated string, each item is a column name, in the same order of fields.
     Please notice: don't leave blank before or after comma.
 
 * `TBLPROPERTIES`

--- a/sdk/src/main/java/com/aliyun/openservices/tablestore/hadoop/PrimaryKeyWritable.java
+++ b/sdk/src/main/java/com/aliyun/openservices/tablestore/hadoop/PrimaryKeyWritable.java
@@ -19,8 +19,12 @@
 package com.aliyun.openservices.tablestore.hadoop;
 
 import java.io.DataInput;
+import java.io.ObjectInput;
 import java.io.DataOutput;
+import java.io.ObjectOutput;
 import java.io.IOException;
+import java.io.EOFException;
+import java.io.Externalizable;
 import org.apache.hadoop.io.WritableComparable;
 import com.alicloud.openservices.tablestore.model.PrimaryKey;
 import com.alicloud.openservices.tablestore.model.PrimaryKeyColumn;
@@ -28,7 +32,7 @@ import com.alicloud.openservices.tablestore.model.PrimaryKeyValue;
 import com.alicloud.openservices.tablestore.model.PrimaryKeyType;
 import com.alicloud.openservices.tablestore.core.utils.Preconditions;
 
-public class PrimaryKeyWritable implements WritableComparable<PrimaryKeyWritable> {
+public class PrimaryKeyWritable implements WritableComparable<PrimaryKeyWritable>, Externalizable {
     private PrimaryKey primaryKey = null;
 
     public PrimaryKeyWritable() {
@@ -133,6 +137,17 @@ public class PrimaryKeyWritable implements WritableComparable<PrimaryKeyWritable
         Preconditions.checkNotNull(primaryKey, "The primary key should not be null.");
         Preconditions.checkNotNull(o.primaryKey, "The primary key should not be null.");
         return primaryKey.compareTo(o.primaryKey);
+    }
+
+    public void readExternal(ObjectInput in)
+        throws IOException,
+               ClassNotFoundException
+    {
+        this.readFields(in);
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        this.write(out);
     }
 }
 

--- a/sdk/src/main/java/com/aliyun/openservices/tablestore/hadoop/RowWritable.java
+++ b/sdk/src/main/java/com/aliyun/openservices/tablestore/hadoop/RowWritable.java
@@ -19,16 +19,19 @@
 package com.aliyun.openservices.tablestore.hadoop;
 
 import java.io.DataInput;
+import java.io.ObjectInput;
 import java.io.DataOutput;
+import java.io.ObjectOutput;
 import java.io.IOException;
 import java.io.EOFException;
+import java.io.Externalizable;
 import org.apache.hadoop.io.Writable;
 import com.alicloud.openservices.tablestore.model.Row;
 import com.alicloud.openservices.tablestore.model.Column;
 import com.alicloud.openservices.tablestore.model.PrimaryKey;
 import com.alicloud.openservices.tablestore.core.utils.Preconditions;
 
-public class RowWritable implements Writable {
+public class RowWritable implements Writable, Externalizable {
     private Row row = null;
 
     public RowWritable() {
@@ -79,6 +82,17 @@ public class RowWritable implements Writable {
         RowWritable w = new RowWritable();
         w.readFields(in);
         return w;
+    }
+
+    public void readExternal(ObjectInput in)
+        throws IOException,
+               ClassNotFoundException
+    {
+        this.readFields(in);
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        this.write(out);
     }
 }
 

--- a/sdk/src/main/java/com/aliyun/openservices/tablestore/hadoop/TableStoreRecordReader.java
+++ b/sdk/src/main/java/com/aliyun/openservices/tablestore/hadoop/TableStoreRecordReader.java
@@ -126,8 +126,9 @@ public class TableStoreRecordReader extends RecordReader<PrimaryKeyWritable, Row
 
         TableStoreInputSplit tsSplit = (TableStoreInputSplit) split;
         scan = tsSplit.getRangeRowQueryCriteria();
-        logger.info("table: {} start: {} end: {}",
+        logger.info("table: {} columns-to-get: {} start: {} end: {}",
             scan.getTableName(),
+            scan.getColumnsToGet(),
             scan.getInclusiveStartPrimaryKey().toString(),
             scan.getExclusiveEndPrimaryKey().toString());
         results = ots.createRangeIterator(new RangeIteratorParameter(scan));


### PR DESCRIPTION
1. PrimaryKeyWritable and RowWritable implements Externalizable to make JAVA-8 lambda workable in Spark
2. slightly improve Hive/SparkSQL doc