### PR TITLE
add secret option for tuning batch size for writing to TableStore

### DIFF
--- a/external/emr-tablestore/src/main/java/com/aliyun/openservices/tablestore/hadoop/TableStore.java
+++ b/external/emr-tablestore/src/main/java/com/aliyun/openservices/tablestore/hadoop/TableStore.java
@@ -26,8 +26,8 @@ import com.alicloud.openservices.tablestore.SyncClient;
 import com.alicloud.openservices.tablestore.core.utils.Preconditions;
 
 public class TableStore {
-    static final String ENDPOINT = "TABLESTORE_ENDPOINT";
-    static final String CREDENTIAL = "TABLESTORE_CREDENTIAL";
+    public static final String ENDPOINT = "TABLESTORE_ENDPOINT";
+    public static final String CREDENTIAL = "TABLESTORE_CREDENTIAL";
 
     /**
      * Set access-key id/secret into a JobContext.

--- a/external/emr-tablestore/src/main/java/com/aliyun/openservices/tablestore/hive/TableStoreConsts.java
+++ b/external/emr-tablestore/src/main/java/com/aliyun/openservices/tablestore/hive/TableStoreConsts.java
@@ -25,6 +25,7 @@ public class TableStoreConsts {
     final public static String ACCESS_KEY_ID = "tablestore.access_key_id";
     final public static String ACCESS_KEY_SECRET = "tablestore.access_key_secret";
     final public static String SECURITY_TOKEN = "tablestore.security_token";
+    final public static String MAX_UPDATE_BATCH_SIZE = "tablestore.max_update_batch_size";
 
     final public static String COLUMNS_MAPPING = "tablestore.columns.mapping";
 
@@ -36,5 +37,6 @@ public class TableStoreConsts {
     final public static String[] OPTIONALS = new String[] {
         INSTANCE,
         SECURITY_TOKEN,
+        MAX_UPDATE_BATCH_SIZE,
         COLUMNS_MAPPING};
 }


### PR DESCRIPTION
* "TABLESTORE_MAX_UPDATE_BATCH_SIZE" for Hadoop/Spark
* "tablestore.max_update_batch_size" for Hive