### PR TITLE
fix create default parition

### DIFF
--- a/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/datasource/ODPSWriter.scala
+++ b/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/datasource/ODPSWriter.scala
@@ -92,6 +92,9 @@ class ODPSWriter(
     }
 
     if (shouldUpload) {
+      if (isPartitionTable && defaultCreate) {
+        odpsUtils.createPartition(project, table, partitionSpec)
+      }
       def writeToFile(schema: StructType, iter: Iterator[Row]) {
         val account_ = new AliyunAccount(accessKeyId, accessKeySecret)
         val odps_ = new Odps(account_)


### PR DESCRIPTION
when we want to create the partition which does not exist in the partition table, we can use `allowCreatNewPartition` set to true.