### PR TITLE
Fix some datetime issues

### DIFF
--- a/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/odps/OdpsOps.scala
+++ b/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/odps/OdpsOps.scala
@@ -706,7 +706,7 @@ class OdpsOps(@transient sc: SparkContext, accessKeyId: String,
           case "STRING" => StructField(tableSchema(e)._1, StringType, true)
           case "DOUBLE" => StructField(tableSchema(e)._1, DoubleType, true)
           case "BOOLEAN" => StructField(tableSchema(e)._1, BooleanType, true)
-          case "DATETIME" => StructField(tableSchema(e)._1, DateType, true)
+          case "DATETIME" => StructField(tableSchema(e)._1, TimestampType, true)
         }
       })
     )
@@ -720,7 +720,11 @@ class OdpsOps(@transient sc: SparkContext, accessKeyId: String,
         case OdpsType.BIGINT => record.getBigint(idx)
         case OdpsType.DOUBLE => record.getDouble(idx)
         case OdpsType.BOOLEAN => record.getBoolean(idx)
-        case OdpsType.DATETIME => new java.sql.Date(record.getDatetime(idx).getTime)
+        case OdpsType.DATETIME =>
+          val dt = record.getDatetime(idx)
+          if (dt != null) {
+            new java.sql.Timestamp(dt.getTime)
+          } else null
         case OdpsType.STRING => record.getString(idx)
       }
     }

--- a/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/odps/PythonOdpsAPI.scala
+++ b/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/odps/PythonOdpsAPI.scala
@@ -43,7 +43,7 @@ class PythonOdpsAPI(
       odpsUrl: String,
       tunnelUrl: String) extends Logging with Serializable {
 
-  val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
+  val dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
   val odpsOps = OdpsOps(jsc.sc, accessKeyId, accessKeySecret, odpsUrl, tunnelUrl)
 
   def readTable(
@@ -126,7 +126,11 @@ class PythonOdpsAPI(
         case OdpsType.BIGINT => record.getBigint(idx)
         case OdpsType.DOUBLE => record.getDouble(idx)
         case OdpsType.BOOLEAN => record.getBoolean(idx)
-        case OdpsType.DATETIME => dateFormat.format(record.getDatetime(idx))
+        case OdpsType.DATETIME =>
+          val dt = record.getDatetime(idx)
+          if (dt != null) {
+            dateFormat.format(record.getDatetime(idx))
+          } else null
         case OdpsType.STRING => if(isBytes == 1) record.getBytes(idx) else record.getString(idx)
       }
     }


### PR DESCRIPTION
This PR fix two issues:
1. `DateType` in SparkSQL will lose the `hour/minute/second` info, so we change `DateType` to `TimeStampType`.

2. when read data from Odps which contains a NULL Date value, it will cause a NPE, so we also fix it.