### PR TITLE
[Spark-1.x]Fix some datetime issues

### DIFF
--- a/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/odps/OdpsOps.scala
+++ b/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/odps/OdpsOps.scala
@@ -708,7 +708,7 @@ class OdpsOps(@transient sc: SparkContext, accessKeyId: String,
           case "STRING" => StructField(tableSchema(e)._1, StringType, true)
           case "DOUBLE" => StructField(tableSchema(e)._1, DoubleType, true)
           case "BOOLEAN" => StructField(tableSchema(e)._1, BooleanType, true)
-          case "DATETIME" => StructField(tableSchema(e)._1, DateType, true)
+          case "DATETIME" => StructField(tableSchema(e)._1, TimestampType, true)
         }
       })
     )
@@ -722,7 +722,11 @@ class OdpsOps(@transient sc: SparkContext, accessKeyId: String,
         case OdpsType.BIGINT => record.getBigint(idx)
         case OdpsType.DOUBLE => record.getDouble(idx)
         case OdpsType.BOOLEAN => record.getBoolean(idx)
-        case OdpsType.DATETIME => new java.sql.Date(record.getDatetime(idx).getTime)
+        case OdpsType.DATETIME =>
+          val dt = record.getDatetime(idx)
+          if (dt != null) {
+            new java.sql.Timestamp(dt.getTime)
+          } else null
         case OdpsType.STRING => record.getString(idx)
       }
     }

--- a/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/odps/PythonOdpsAPI.scala
+++ b/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/odps/PythonOdpsAPI.scala
@@ -40,7 +40,7 @@ class PythonOdpsAPI(
       tunnelUrl: String) extends Logging with Serializable {
 
   val odpsOps = OdpsOps(jsc.sc, accessKeyId, accessKeySecret, odpsUrl, tunnelUrl)
-  val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
+  val dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
 
   def readTable(
       project: String,
@@ -122,7 +122,11 @@ class PythonOdpsAPI(
         case OdpsType.BIGINT => record.getBigint(idx)
         case OdpsType.DOUBLE => record.getDouble(idx)
         case OdpsType.BOOLEAN => record.getBoolean(idx)
-        case OdpsType.DATETIME => dateFormat.format(record.getDatetime(idx))
+        case OdpsType.DATETIME =>
+          val dt = record.getDatetime(idx)
+          if (dt != null) {
+            dateFormat.format(record.getDatetime(idx))
+          } else null
         case OdpsType.STRING => if(isBytes == 1) record.getBytes(idx) else record.getString(idx)
       }
     }


### PR DESCRIPTION
This PR fix two issues:

DateType in SparkSQL will lose the hour/minute/second info, so we change DateType to TimeStampType.

when read data from Odps which contains a NULL Date value, it will cause a NPE, so we also fix it.