### PR TITLE
add support for DECIMAL field of the ODPS

### DIFF
--- a/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/odps/OdpsOps.scala
+++ b/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/odps/OdpsOps.scala
@@ -707,6 +707,7 @@ class OdpsOps(@transient sc: SparkContext, accessKeyId: String,
           case "DOUBLE" => StructField(tableSchema(e)._1, DoubleType, true)
           case "BOOLEAN" => StructField(tableSchema(e)._1, BooleanType, true)
           case "DATETIME" => StructField(tableSchema(e)._1, TimestampType, true)
+          case "DECIMAL" => StructField(tableSchema(e)._1, DecimalType(15, 2), true)
         }
       })
     )
@@ -726,6 +727,7 @@ class OdpsOps(@transient sc: SparkContext, accessKeyId: String,
             new java.sql.Timestamp(dt.getTime)
           } else null
         case OdpsType.STRING => record.getString(idx)
+        case OdpsType.DECIMAL => record.getDecimal(idx)
       }
     }
   }
@@ -743,6 +745,7 @@ class OdpsOps(@transient sc: SparkContext, accessKeyId: String,
         case OdpsType.BOOLEAN => "BOOLEAN"
         case OdpsType.DATETIME => "DATETIME"
         case OdpsType.STRING => "STRING"
+        case OdpsType.DECIMAL => "DECIMAL"
       }
       (name, colType)
     })
@@ -759,6 +762,7 @@ class OdpsOps(@transient sc: SparkContext, accessKeyId: String,
       case OdpsType.BOOLEAN => "BOOLEAN"
       case OdpsType.DATETIME => "DATETIME"
       case OdpsType.STRING => "STRING"
+      case OdpsType.DECIMAL => "DECIMAL"
     }
 
     (idx.toString, colType)
@@ -776,6 +780,7 @@ class OdpsOps(@transient sc: SparkContext, accessKeyId: String,
       case OdpsType.BOOLEAN => "BOOLEAN"
       case OdpsType.DATETIME => "DATETIME"
       case OdpsType.STRING => "STRING"
+      case OdpsType.DECIMAL => "DECIMAL"
     }
 
     (name, colType)

--- a/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/utils/OdpsUtils.scala
+++ b/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/utils/OdpsUtils.scala
@@ -200,6 +200,7 @@ class OdpsUtils(odps: Odps) extends Logging{
         case OdpsType.BOOLEAN => "BOOLEAN"
         case OdpsType.DATETIME => "DATETIME"
         case OdpsType.STRING => "STRING"
+        case OdpsType.DECIMAL => "DECIMAL"
       }
       (name, colType)
     })
@@ -223,13 +224,14 @@ class OdpsUtils(odps: Odps) extends Logging{
       case OdpsType.BOOLEAN => "BOOLEAN"
       case OdpsType.DATETIME => "DATETIME"
       case OdpsType.STRING => "STRING"
+      case OdpsType.DECIMAL => "DECIMAL"
     }
 
     (idx.toString, colType)
   }
 
   /**
-   * Get information of specific column vai column index.
+   * Get information of specific column via column index.
    * @param project The name of ODPS project.
    * @param table The name of ODPS table.
    * @param idx The index of specific column.
@@ -247,6 +249,7 @@ class OdpsUtils(odps: Odps) extends Logging{
       case OdpsType.BOOLEAN => "BOOLEAN"
       case OdpsType.DATETIME => "DATETIME"
       case OdpsType.STRING => "STRING"
+      case OdpsType.DECIMAL => "DECIMAL"
     }
 
     (name, colType)


### PR DESCRIPTION
add support for DECIMAL field of the ODPS table with in
aliyun-emapreduce-sdk

Change-Id: Idd75faaa56c08a768eea8e8145dcd379ee6f3933
Signed-off-by: liukaitj <liukai.tci@gmail.com>