### PR TITLE
Failed to read ODPS table with STRING column

### DIFF
--- a/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/odps/datasource/ODPSRDD.scala
+++ b/external/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/odps/datasource/ODPSRDD.scala
@@ -126,7 +126,8 @@ class ODPSRDD(
                         case date2: java.util.Date =>
                           mutableRow.setInt(idx, DateTimeUtils.fromJavaDate(new Date(date2.getTime)))
                         case null => mutableRow.update(idx, null)
-                        case _ => throw new SQLException(s"Unknown type")
+                        case _ => throw new SQLException(s"Unknown type" +
+                          s" ${value.getClass.getCanonicalName}")
                       }
                     case TimestampType =>
                       val value = r.toArray.apply(idx)
@@ -134,7 +135,8 @@ class ODPSRDD(
                         case timestamp: java.sql.Timestamp =>
                           mutableRow.setLong(idx, DateTimeUtils.fromJavaTimestamp(timestamp))
                         case null => mutableRow.update(idx, null)
-                        case _ => throw new SQLException(s"Unknown type")
+                        case _ => throw new SQLException(s"Unknown type" +
+                          s" ${value.getClass.getCanonicalName}")
                       }
                     case DecimalType.SYSTEM_DEFAULT =>
                       val value = r.toArray.apply(idx)
@@ -157,7 +159,8 @@ class ODPSRDD(
                         case e: java.lang.Integer =>
                           mutableRow.update(idx, e.toInt)
                         case null => mutableRow.update(idx, null)
-                        case _ => throw new SQLException(s"Unknown type")
+                        case _ => throw new SQLException(s"Unknown type" +
+                          s" ${value.getClass.getCanonicalName}")
                       }
                     case StringType =>
                       val value = r.toArray.apply(idx)
@@ -168,8 +171,11 @@ class ODPSRDD(
                           mutableRow.update(idx, UTF8String.fromString(e.toString))
                         case e: String =>
                           mutableRow.update(idx, UTF8String.fromString(e))
+                        case e: Array[Byte] =>
+                          mutableRow.update(idx, UTF8String.fromBytes(e))
                         case null => mutableRow.update(idx, null)
-                        case _ => throw new SQLException(s"Unknown type")
+                        case _ => throw new SQLException(s"Unknown type" +
+                          s" ${value.getClass.getCanonicalName}")
                       }
                     case BinaryType =>
                       val value = r.toArray.apply(idx)
@@ -177,7 +183,8 @@ class ODPSRDD(
                         case e: com.aliyun.odps.data.Binary =>
                           mutableRow.update(idx, e.data())
                         case null => mutableRow.update(idx, null)
-                        case _ => throw new SQLException(s"Unknown type")
+                        case _ => throw new SQLException(s"Unknown type" +
+                          s" ${value.getClass.getCanonicalName}")
                       }
                     case NullType =>
                       mutableRow.setNullAt(idx)


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
scala> df.show
18/07/17 13:13:05 WARN scheduler.TaskSetManager: Lost task 0.0 in stage 0.0 (TID 0, emr-worker-1.cluster-69961, executor 2): java.sql.SQLException: Unknown type
    at org.apache.spark.aliyun.odps.datasource.ODPSRDD$$anon$1$$anonfun$getNext$1.apply(ODPSRDD.scala:172)
    at org.apache.spark.aliyun.odps.datasource.ODPSRDD$$anon$1$$anonfun$getNext$1.apply(ODPSRDD.scala:84)
    at scala.collection.immutable.List.foreach(List.scala:381)
    at org.apache.spark.aliyun.odps.datasource.ODPSRDD$$anon$1.getNext(ODPSRDD.scala:84)
    at org.apache.spark.aliyun.odps.datasource.ODPSRDD$$anon$1.getNext(ODPSRDD.scala:54)
    at org.apache.spark.util.NextIterator.hasNext(NextIterator.scala:73)
    at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
    at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
    at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
    at org.apache.spark.sql.execution.WholeStageCodegenExec$$anonfun$10$$anon$1.hasNext(WholeStageCodegenExec.scala:614)
    at org.apache.spark.sql.execution.SparkPlan$$anonfun$2.apply(SparkPlan.scala:253)
    at org.apache.spark.sql.execution.SparkPlan$$anonfun$2.apply(SparkPlan.scala:247)
    at org.apache.spark.rdd.RDD$$anonfun$mapPartitionsInternal$1$$anonfun$apply$25.apply(RDD.scala:830)
    at org.apache.spark.rdd.RDD$$anonfun$mapPartitionsInternal$1$$anonfun$apply$25.apply(RDD.scala:830)
    at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:38)
    at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
    at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
    at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:38)
    at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
    at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
    at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:87)
    at org.apache.spark.scheduler.Task.run(Task.scala:109)
    at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:345)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
