### PR TITLE
new feature: support datahub direct api in spark streaming

### DIFF
--- a/emr-datahub/pom.xml
+++ b/emr-datahub/pom.xml
@@ -57,6 +57,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.101tec</groupId>
+            <artifactId>zkclient</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
             <scope>test</scope>

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/CanCommitOffsets.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/CanCommitOffsets.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.aliyun.datahub
+
+import org.apache.spark.annotation.Experimental
+
+@Experimental
+trait CanCommitOffsets {
+  /**
+    *  :: Experimental ::
+    * Queue up offset ranges for commit to Loghub at a future time.  Threadsafe.
+    * This is only needed if you intend to store offsets in Loghub, instead of your own store.
+    */
+  @Experimental
+  def commitAsync(): Unit
+}

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/CanCommitOffsets.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/CanCommitOffsets.scala
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.streaming.aliyun.datahub
 
 import org.apache.spark.annotation.Experimental
@@ -22,10 +21,10 @@ import org.apache.spark.annotation.Experimental
 @Experimental
 trait CanCommitOffsets {
   /**
-    *  :: Experimental ::
-    * Queue up offset ranges for commit to Loghub at a future time.  Threadsafe.
-    * This is only needed if you intend to store offsets in Loghub, instead of your own store.
-    */
+   *  :: Experimental ::
+   * Queue up offset ranges for commit to Loghub at a future time.  Threadsafe.
+   * This is only needed if you intend to store offsets in Loghub, instead of your own store.
+   */
   @Experimental
   def commitAsync(): Unit
 }

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubClientAgent.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubClientAgent.scala
@@ -1,15 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.streaming.aliyun.datahub
 
 import com.aliyun.datahub.common.data.RecordSchema
 import com.aliyun.datahub.exception.{InvalidParameterException, MalformedRecordException, ResourceNotFoundException}
 import com.aliyun.datahub.model.GetCursorRequest.CursorType
-import com.aliyun.datahub.{DatahubClient, DatahubConfiguration}
 import com.aliyun.datahub.model._
+import com.aliyun.datahub.{DatahubClient, DatahubConfiguration}
 import org.apache.spark.internal.Logging
+import org.codehaus.jackson.JsonNode
+import org.codehaus.jackson.map.ObjectMapper
+import org.codehaus.jackson.node.ObjectNode
 
-/**
-  * @date 2018/09/01
-  */
 class DatahubClientAgent(conf: DatahubConfiguration) extends Logging {
 
   private val datahubServiceMaxRetry = 3
@@ -57,6 +74,80 @@ class DatahubClientAgent(conf: DatahubConfiguration) extends Logging {
       }
     }
     logError(s"retry to getCursor exceed max retry times[$datahubServiceMaxRetry].")
+    throw currentException
+  }
+
+  def getCursor(projectName: String, topicName: String, shardId: String, offset: OffsetContext.Offset):GetCursorResult = {
+    var retry = 0
+    var currentException: Exception = null
+    while (retry <= datahubServiceMaxRetry) {
+      try{
+        val request = new GetCursorRequest(projectName, topicName, shardId, CursorType.SEQUENCE, offset.getSequence)
+        return client.getCursor(request)
+      }
+      catch {
+        case e: ResourceNotFoundException => {
+          throw e
+        }
+        case e: InvalidParameterException => {
+          throw e
+        }
+        case e: Exception => {
+          retry += 1
+          currentException = e
+          logError(s"catch exception when getCursor, start to retry $retry-times")
+        }
+      }
+    }
+    logError(s"retry to getCursor exceed max retry times[$datahubServiceMaxRetry].")
+    throw currentException
+  }
+
+  def getRecords(projectName: String, topicName: String, shardId: String, cursor: String, limit: Int, schema: RecordSchema): GetRecordsResult = {
+    var retry = 0
+    var currentException: Exception = null
+    while (retry <= datahubServiceMaxRetry) {
+      try
+        return client.getRecords(projectName, topicName, shardId, cursor, limit, schema)
+      catch {
+        case e: MalformedRecordException => {
+          throw e
+        }
+        case e: ResourceNotFoundException => {
+          throw e
+        }
+        case e: InvalidParameterException => {
+          throw e
+        }
+        case e: Exception => {
+          retry += 1
+          currentException = e
+          logError(s"catch exception when getRecords, start to retry $retry-times")
+        }
+      }
+    }
+    logError(s"retry to getRecords exceed max retry times[$datahubServiceMaxRetry].")
+    throw currentException
+  }
+
+  def listShards(project: String, topic: String): ListShardResult = {
+    var retry = 0
+    var currentException: Exception = null
+    while (retry <= datahubServiceMaxRetry) {
+      try
+        return client.listShard(project, topic)
+      catch {
+        case e: InvalidParameterException => {
+          throw e
+        }
+        case e: Exception => {
+          retry += 1
+          currentException = e
+          logError(s"catch exception when initOffsetContext, start to retry $retry-times")
+        }
+      }
+    }
+    logError(s"retry to initOffsetContext exceed max retry times[$datahubServiceMaxRetry")
     throw currentException
   }
 
@@ -143,31 +234,34 @@ class DatahubClientAgent(conf: DatahubConfiguration) extends Logging {
     logError(s"retry to updateOffsetContext exceed max retry times[$datahubServiceMaxRetry].")
     throw currentException
   }
+}
 
-  def getRecords(projectName: String, topicName: String, shardId: String, cursor: String, limit: Int, schema: RecordSchema): GetRecordsResult = {
-    var retry = 0
-    var currentException: Exception = null
-    while (retry <= datahubServiceMaxRetry) {
-      try
-        return client.getRecords(projectName, topicName, shardId, cursor, limit, schema)
-      catch {
-        case e: MalformedRecordException => {
-          throw e
-        }
-        case e: ResourceNotFoundException => {
-          throw e
-        }
-        case e: InvalidParameterException => {
-          throw e
-        }
-        case e: Exception => {
-          retry += 1
-          currentException = e
-          logError(s"catch exception when getRecords, start to retry $retry-times")
-        }
-      }
-    }
-    logError(s"retry to getRecords exceed max retry times[$datahubServiceMaxRetry].")
-    throw currentException
+object JacksonParser {
+  val objectMapper = new ObjectMapper()
+
+  def getOffsetContext(offsetContextObjectNode: JsonNode): OffsetContext = {
+    offsetContextObjectNode.getBinaryValue
+    val offset = new OffsetContext.Offset(offsetContextObjectNode.get("Sequence").asLong(), offsetContextObjectNode.get("Timestamp").asLong())
+    new OffsetContext(offsetContextObjectNode.get("Project").asText(), offsetContextObjectNode.get("Topic").asText(), offsetContextObjectNode.get("SubId").asText(),
+      offsetContextObjectNode.get("ShardId").asText(), offset, offsetContextObjectNode.get("Version").asLong(), offsetContextObjectNode.get("SessionId").asText())
+  }
+
+  def getOffsetContext(offsetContextStr: String): OffsetContext = {
+    getOffsetContext(objectMapper.readTree(offsetContextStr))
+  }
+
+  def getOffset(offsetStr: String): OffsetContext.Offset = {
+    getOffset(objectMapper.readTree(offsetStr))
+  }
+
+  def getOffset(offset: JsonNode): OffsetContext.Offset = {
+    new OffsetContext.Offset(offset.get("Sequence").asLong(), offset.get("Timestamp").asLong())
+  }
+
+  def toJsonNode(offset: OffsetContext.Offset): ObjectNode = {
+    val node = objectMapper.createObjectNode()
+    node.put("Sequence", offset.getSequence)
+    node.put("Timestamp", offset.getTimestamp)
+    node
   }
 }

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubClientAgent.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubClientAgent.scala
@@ -177,6 +177,10 @@ class DatahubClientAgent(conf: DatahubConfiguration) extends Logging {
     throw currentException
   }
 
+  /**
+   * @InvalidParameterException one possible reason is when timestamp of oldest data in datahub
+   *                           is larger than consume offset in offsetCtx cause data is expired
+   */
   def getNextOffsetCursor(offsetCtx: OffsetContext): GetCursorResult = {
     var retry = 0
     var currentException: Exception = null

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubIterator.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubIterator.scala
@@ -20,6 +20,7 @@ package org.apache.spark.streaming.aliyun.datahub
 import java.util.concurrent.LinkedBlockingQueue
 
 import scala.collection.JavaConversions._
+
 import com.aliyun.datahub.model.{OffsetContext, RecordEntry}
 import org.I0Itec.zkclient.ZkClient
 import org.apache.spark.TaskContext
@@ -57,7 +58,7 @@ private class DatahubIterator(
       }
       dataBuffer.poll()
     } else {
-      Array.empty
+      Array.empty[Byte]
     }
   }
 

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubIterator.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubIterator.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.aliyun.datahub
+
+import java.util.concurrent.LinkedBlockingQueue
+
+import scala.collection.JavaConversions._
+import com.aliyun.datahub.model.{OffsetContext, RecordEntry}
+import org.I0Itec.zkclient.ZkClient
+import org.apache.spark.TaskContext
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.NextIterator
+
+private class DatahubIterator(
+    datahubClient: DatahubClientAgent,
+    endpoint: String,
+    project: String,
+    topic: String,
+    shardId: String,
+    cursor: String,
+    count: Int,
+    subId: String,
+    accessId: String,
+    accessKey: String,
+    func: RecordEntry => String,
+    zkClient: ZkClient,
+    checkpointDir: String,
+    context: TaskContext) extends NextIterator[Array[Byte]] with Logging{
+  private val datahubShardMaxSize = 512
+  private val step = 100
+  private var dataBuffer = new LinkedBlockingQueue[Array[Byte]](datahubShardMaxSize * step * 10)
+  private var hasRead = 0
+  private var lastOffset: OffsetContext.Offset = null
+  private val inputMetrcis = context.taskMetrics().inputMetrics
+  private var nextCursor = cursor
+
+  override protected def getNext(): Array[Byte] = {
+    finished = !checkHasNext
+    if (!finished) {
+      if (dataBuffer.isEmpty) {
+        fetchData()
+      }
+      dataBuffer.poll()
+    } else {
+      Array.empty
+    }
+  }
+
+  override protected def close() = {
+    try {
+      inputMetrcis.incRecordsRead(hasRead)
+      dataBuffer.clear()
+      dataBuffer = null
+    } catch {
+      case e: Exception =>
+        logError("Catch exception when close datahub iterator.", e)
+    }
+  }
+
+  private def checkHasNext: Boolean = {
+    val hasNext = hasRead < count || !dataBuffer.isEmpty
+    if (!hasNext) {
+      // commit next offset
+      lastOffset.setSequence(lastOffset.getSequence + 1)
+      writeDataToZk(zkClient, s"$checkpointDir/datahub/commit/$project/$topic/$subId/$shardId",
+        JacksonParser.toJsonNode(lastOffset).toString)
+    }
+    hasNext
+  }
+
+  private def fetchData() = {
+    val topicResult = datahubClient.getTopic(project, topic)
+    val schema = topicResult.getRecordSchema
+    val limit = if (count - hasRead >= step) step else count - hasRead
+    val recordResult = datahubClient.getRecords(project, topic, shardId, nextCursor, limit, schema)
+    val num = recordResult.getRecordCount
+    if (num == 0) {
+      logDebug("Fetch 0 records from datahub, sleep 100ms and fetch again")
+      Thread.sleep(100)
+    } else {
+      recordResult.getRecords.foreach(record => {
+        dataBuffer.offer(func(record).getBytes())
+        lastOffset = record.getOffset
+      })
+      nextCursor = recordResult.getNextCursor
+      hasRead = hasRead + num
+      logDebug(s"shardId: $shardId, nextCursor: $nextCursor, hasRead: $hasRead, count: $count")
+    }
+  }
+
+  private def writeDataToZk(zkClient: ZkClient, path:String, data:String) = {
+    if (!zkClient.exists(path)) {
+      zkClient.createPersistent(path, true)
+    }
+    zkClient.writeData(path, data)
+  }
+}

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubIterator.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubIterator.scala
@@ -42,9 +42,8 @@ private class DatahubIterator(
     zkClient: ZkClient,
     checkpointDir: String,
     context: TaskContext) extends NextIterator[Array[Byte]] with Logging{
-  private val datahubShardMaxSize = 512
   private val step = 100
-  private var dataBuffer = new LinkedBlockingQueue[Array[Byte]](datahubShardMaxSize * step * 10)
+  private var dataBuffer = new LinkedBlockingQueue[Array[Byte]](step)
   private var hasRead = 0
   private var lastOffset: OffsetContext.Offset = null
   private val inputMetrcis = context.taskMetrics().inputMetrics

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubRDD.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubRDD.scala
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.aliyun.datahub
+
+import java.io.UnsupportedEncodingException
+import java.nio.charset.StandardCharsets
+
+import com.aliyun.datahub.DatahubConfiguration
+import com.aliyun.datahub.auth.AliyunAccount
+import com.aliyun.datahub.model.RecordEntry
+import org.I0Itec.zkclient.ZkClient
+import org.I0Itec.zkclient.serialize.ZkSerializer
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{InterruptibleIterator, Partition, SparkContext, TaskContext}
+
+import scala.collection.mutable.ArrayBuffer
+
+class DatahubRDD(
+    @transient _sc: SparkContext,
+    duration: Long,
+    endpoint: String,
+    project: String,
+    topic: String,
+    subId: String,
+    accessId: String,
+    accessKey: String,
+    func: RecordEntry => String,
+    shardOffsets: ArrayBuffer[(String, String, String)],
+    zkParam: Map[String, String],
+    checkpointDir: String) extends RDD[Array[Byte]](_sc, Nil) with Logging{
+
+  @transient private var zkClient = DatahubRDD.getClient(zkParam, accessId, accessKey, endpoint)._1
+  @transient private var datahubClientAgent = DatahubRDD.getClient(zkParam, accessId, accessKey, endpoint)._2
+
+  override def compute(split: Partition, context: TaskContext): Iterator[Array[Byte]] = {
+    zkClient = DatahubRDD.getClient(zkParam, accessId, accessKey, endpoint)._1
+    zkClient.setZkSerializer(new ZkSerializer{
+      override def serialize(data: scala.Any): Array[Byte] = {
+        data.asInstanceOf[String].getBytes(StandardCharsets.UTF_8)
+      }
+
+      override def deserialize(bytes: Array[Byte]): AnyRef = {
+        new String(bytes, StandardCharsets.UTF_8)
+      }
+    })
+    datahubClientAgent = DatahubRDD.getClient(zkParam, accessId, accessKey, endpoint)._2
+
+    val partition = split.asInstanceOf[ShardPartition]
+    try {
+      new InterruptibleIterator[Array[Byte]](context, new DatahubIterator(datahubClientAgent, endpoint, project, topic, partition.shardId, partition.cursor,
+        partition.count, subId, accessId, accessKey, func, zkClient, checkpointDir, context))
+    } catch {
+      case e: Exception =>
+        logError("Fail to build DatahubIterator.", e)
+        Iterator.empty.asInstanceOf[Iterator[Array[Byte]]]
+    }
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    val rate = _sc.getConf.get("spark.streaming.datahub.maxRatePerShard", "10000").toInt
+    var count = rate * duration / 1000
+
+    datahubClientAgent = DatahubRDD.getClient(zkParam, accessId, accessKey, endpoint)._2
+    shardOffsets.zipWithIndex.map {
+      case (so, index) =>
+        val shardId = so._1
+        val startOffset = JacksonParser.getOffset(so._2)
+        val endOffset = JacksonParser.getOffset(so._3)
+        if (count > endOffset.getSequence - startOffset.getSequence + 1) {
+          count = endOffset.getSequence - startOffset.getSequence + 1
+        }
+        val cursor = datahubClientAgent.getCursor(project, topic, shardId, startOffset).getCursor
+        new ShardPartition(id, shardId, index, cursor, count.toInt).asInstanceOf[Partition]
+    }.toArray
+  }
+}
+
+private class ShardPartition(
+    rddId: Int,
+    val shardId: String,
+    partitionId: Int,
+    val cursor: String,
+    val count: Int) extends Partition {
+  override def index: Int = partitionId
+  override def hashCode(): Int = 41 * (41 + rddId) + index
+}
+
+object DatahubRDD extends Logging {
+  var zkClient: ZkClient = null
+  var datahubClient: DatahubClientAgent = null
+
+  def getClient(zkParam: Map[String, String], accessId: String, accessKey: String, endpoint: String): (ZkClient, DatahubClientAgent) = {
+    if (zkClient ==  null || datahubClient == null) {
+      val zkServers = zkParam.getOrElse("zookeeper.connect", "localhost:2181")
+      val sessionTimeout = zkParam.getOrElse("zookeeper.session.timeout.ms", "6000").toInt
+      val connectionTimeout = zkParam.getOrElse("zookeeper.connection.timeout.ms", sessionTimeout.toString).toInt
+      zkClient = new ZkClient(zkServers, sessionTimeout, connectionTimeout)
+      zkClient.setZkSerializer(new ZkSerializer {
+        override def serialize(data: scala.Any): Array[Byte] = {
+          try {
+            data.asInstanceOf[String].getBytes(StandardCharsets.UTF_8)
+          } catch {
+            case e: UnsupportedEncodingException =>
+              logError("Fail to store data to Zookeeper.", e)
+              null
+          }
+        }
+
+        override def deserialize(bytes: Array[Byte]): AnyRef = {
+          if (bytes == null) {
+            return null
+          }
+          try {
+            new String(bytes, StandardCharsets.UTF_8)
+          } catch{
+            case e: UnsupportedEncodingException =>
+              logError("Fail to get data from Zookeeper.", e)
+              null
+          }
+        }
+      })
+      datahubClient = new DatahubClientAgent(new DatahubConfiguration(new AliyunAccount(accessId, accessKey), endpoint))
+    }
+
+    (zkClient, datahubClient)
+  }
+
+  override def finalize(): Unit = {
+    super.finalize()
+    if (zkClient != null) {
+      try {
+        zkClient.close()
+        zkClient = null
+      } catch {
+        case e:Exception =>
+          logError("Catch exception when close Zookeeper client", e)
+      }
+    }
+  }
+}

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubUtils.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubUtils.scala
@@ -22,6 +22,7 @@ import com.aliyun.datahub.model.RecordEntry
 import com.aliyun.datahub.{DatahubClient, DatahubConfiguration}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.streaming.api.java.JavaStreamingContext
 import org.apache.spark.streaming.dstream.DStream
 
 object DatahubUtils {
@@ -49,6 +50,21 @@ object DatahubUtils {
         func,
         storageLevel)
     }
+  }
+
+  def createStream(
+      jssc: JavaStreamingContext,
+      projectName: String,
+      topicName: String,
+      subId: String,
+      accessKeyId: String,
+      accessKeySecret: String,
+      endpoint: String,
+      shardId: String,
+      func: RecordEntry => String,
+      storageLevel: StorageLevel): DStream[Array[Byte]] = {
+    createStream(jssc.ssc, projectName, topicName, subId, accessKeyId, accessKeySecret, endpoint, shardId, func,
+      storageLevel)
   }
 
   def createStream(
@@ -82,6 +98,19 @@ object DatahubUtils {
     dStream
   }
 
+  def createStream(
+      jssc: JavaStreamingContext,
+      projectName: String,
+      topicName: String,
+      subId: String,
+      accessKeyId: String,
+      accessKeySecret: String,
+      endpoint: String,
+      func: RecordEntry => String,
+      storageLevel: StorageLevel): DStream[Array[Byte]] = {
+    createStream(jssc.ssc, projectName, topicName, subId, accessKeyId, accessKeySecret, endpoint, func, storageLevel)
+  }
+
   def createDirectStream(ssc: StreamingContext,
       endpoint: String,
       project: String,
@@ -106,6 +135,19 @@ object DatahubUtils {
     }
   }
 
+  def createDirectStream(jssc: JavaStreamingContext,
+      endpoint: String,
+      project: String,
+      topic: String,
+      subId: String,
+      accessId: String,
+      accessKey: String,
+      func: RecordEntry => String,
+      mode: CursorType,
+      zkParam: Map[String, String]): DStream[Array[Byte]] = {
+    createDirectStream(jssc.ssc, endpoint, project, topic, subId, accessId, accessKey, func, mode, zkParam)
+  }
+
   def createDirectStream(ssc: StreamingContext,
       endpoint: String,
       project: String,
@@ -116,6 +158,91 @@ object DatahubUtils {
       func: RecordEntry => String,
       zkParam: Map[String, String]): DStream[Array[Byte]] = {
     createDirectStream(ssc,
+      endpoint,
+      project,
+      topic,
+      subId,
+      accessId,
+      accessKey,
+      func,
+      CursorType.LATEST,
+      zkParam)
+  }
+
+  def createDirectStream(jssc: JavaStreamingContext,
+      endpoint: String,
+      project: String,
+      topic: String,
+      subId: String,
+      accessId: String,
+      accessKey: String,
+      func: RecordEntry => String,
+      zkParam: Map[String, String]): DStream[Array[Byte]] = {
+    createDirectStream(jssc.ssc,
+      endpoint,
+      project,
+      topic,
+      subId,
+      accessId,
+      accessKey,
+      func,
+      CursorType.LATEST,
+      zkParam)
+  }
+}
+
+class DatahubUtilsHelper {
+  def createStream(
+      jssc: JavaStreamingContext,
+      projectName: String,
+      topicName: String,
+      subId: String,
+      accessKeyId: String,
+      accessKeySecret: String,
+      endpoint: String,
+      shardId: String,
+      func: RecordEntry => String,
+      storageLevel: StorageLevel): DStream[Array[Byte]] = {
+    DatahubUtils.createStream(jssc.ssc, projectName, topicName, subId, accessKeyId, accessKeySecret, endpoint, shardId, func,
+      storageLevel)
+  }
+
+  def createStream(
+      jssc: JavaStreamingContext,
+      projectName: String,
+      topicName: String,
+      subId: String,
+      accessKeyId: String,
+      accessKeySecret: String,
+      endpoint: String,
+      func: RecordEntry => String,
+      storageLevel: StorageLevel): DStream[Array[Byte]] = {
+    DatahubUtils.createStream(jssc.ssc, projectName, topicName, subId, accessKeyId, accessKeySecret, endpoint, func, storageLevel)
+  }
+
+  def createDirectStream(jssc: JavaStreamingContext,
+      endpoint: String,
+      project: String,
+      topic: String,
+      subId: String,
+      accessId: String,
+      accessKey: String,
+      func: RecordEntry => String,
+      mode: CursorType,
+      zkParam: Map[String, String]): DStream[Array[Byte]] = {
+    DatahubUtils.createDirectStream(jssc.ssc, endpoint, project, topic, subId, accessId, accessKey, func, mode, zkParam)
+  }
+
+  def createDirectStream(jssc: JavaStreamingContext,
+      endpoint: String,
+      project: String,
+      topic: String,
+      subId: String,
+      accessId: String,
+      accessKey: String,
+      func: RecordEntry => String,
+      zkParam: Map[String, String]): DStream[Array[Byte]] = {
+    DatahubUtils.createDirectStream(jssc.ssc,
       endpoint,
       project,
       topic,

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubUtils.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubUtils.scala
@@ -26,6 +26,17 @@ import org.apache.spark.streaming.api.java.JavaStreamingContext
 import org.apache.spark.streaming.dstream.DStream
 
 object DatahubUtils {
+  /**
+   * Scala constructor to create a DStream from datahub source.
+   * @param projectName datahub project name
+   * @param topicName datahub topic name
+   * @param subId datahub subscription id
+   * @param accessKeyId aliyun access key id
+   * @param accessKeySecret aliyun access key secret
+   * @param endpoint datahub endpoint
+   * @param shardId datahub topic shard
+   * @param func handle RecordEntry to String
+   */
   def createStream(
       ssc: StreamingContext,
       projectName: String,
@@ -67,6 +78,16 @@ object DatahubUtils {
       storageLevel)
   }
 
+  /**
+   * Scala constructor to create a DStream from datahub source.
+   * @param projectName datahub project name
+   * @param topicName datahub topic name
+   * @param subId datahub subscription id
+   * @param accessKeyId aliyun access key id
+   * @param accessKeySecret aliyun access key secret
+   * @param endpoint datahub endpoint
+   * @param func handle RecordEntry to String
+   */
   def createStream(
       ssc: StreamingContext,
       projectName: String,
@@ -111,7 +132,22 @@ object DatahubUtils {
     createStream(jssc.ssc, projectName, topicName, subId, accessKeyId, accessKeySecret, endpoint, func, storageLevel)
   }
 
-  def createDirectStream(ssc: StreamingContext,
+  /**
+   * :: Experimental ::
+   * Scala constructor for a DStream where
+   * each datahub shard correspond to a RDD partition.
+   * @param project datahub project name
+   * @param topic datahub topic name
+   * @param subId datahub subscription id
+   * @param accessId aliyun access key id
+   * @param accessKey aliyun access key secret
+   * @param endpoint datahub endpoint
+   * @param func handle RecordEntry to String
+   * @param mode datahub cursor type
+   * @param zkParam Zookeeper configuration
+   */
+  def createDirectStream(
+      ssc: StreamingContext,
       endpoint: String,
       project: String,
       topic: String,
@@ -122,7 +158,8 @@ object DatahubUtils {
       mode: CursorType,
       zkParam: Map[String, String]): DStream[Array[Byte]] = {
     ssc.withNamedScope("datahub direct stream") {
-      new DirectDatahubInputDStream(ssc,
+      new DirectDatahubInputDStream(
+        ssc,
         endpoint,
         project,
         topic,
@@ -135,7 +172,8 @@ object DatahubUtils {
     }
   }
 
-  def createDirectStream(jssc: JavaStreamingContext,
+  def createDirectStream(
+      jssc: JavaStreamingContext,
       endpoint: String,
       project: String,
       topic: String,
@@ -148,7 +186,21 @@ object DatahubUtils {
     createDirectStream(jssc.ssc, endpoint, project, topic, subId, accessId, accessKey, func, mode, zkParam)
   }
 
-  def createDirectStream(ssc: StreamingContext,
+  /**
+   * :: Experimental ::
+   * Scala constructor for a DStream where
+   * each datahub shard correspond to a RDD partition.
+   * @param project datahub project name
+   * @param topic datahub topic name
+   * @param subId datahub subscription id
+   * @param accessId aliyun access key id
+   * @param accessKey aliyun access key secret
+   * @param endpoint datahub endpoint
+   * @param func handle RecordEntry to String
+   * @param zkParam Zookeeper configuration
+   */
+  def createDirectStream(
+      ssc: StreamingContext,
       endpoint: String,
       project: String,
       topic: String,
@@ -169,7 +221,8 @@ object DatahubUtils {
       zkParam)
   }
 
-  def createDirectStream(jssc: JavaStreamingContext,
+  def createDirectStream(
+      jssc: JavaStreamingContext,
       endpoint: String,
       project: String,
       topic: String,
@@ -192,6 +245,17 @@ object DatahubUtils {
 }
 
 class DatahubUtilsHelper {
+  /**
+   * Java constructor to create a DStream from datahub source.
+   * @param projectName datahub project name
+   * @param topicName datahub topic name
+   * @param subId datahub subscription id
+   * @param accessKeyId aliyun access key id
+   * @param accessKeySecret aliyun access key secret
+   * @param endpoint datahub endpoint
+   * @param shardId datahub topic shard
+   * @param func handle RecordEntry to String
+   */
   def createStream(
       jssc: JavaStreamingContext,
       projectName: String,
@@ -203,10 +267,29 @@ class DatahubUtilsHelper {
       shardId: String,
       func: RecordEntry => String,
       storageLevel: StorageLevel): DStream[Array[Byte]] = {
-    DatahubUtils.createStream(jssc.ssc, projectName, topicName, subId, accessKeyId, accessKeySecret, endpoint, shardId, func,
+    DatahubUtils.createStream(
+      jssc.ssc,
+      projectName,
+      topicName,
+      subId,
+      accessKeyId,
+      accessKeySecret,
+      endpoint,
+      shardId,
+      func,
       storageLevel)
   }
 
+  /**
+   * Java constructor to create a DStream from datahub source.
+   * @param projectName datahub project name
+   * @param topicName datahub topic name
+   * @param subId datahub subscription id
+   * @param accessKeyId aliyun access key id
+   * @param accessKeySecret aliyun access key secret
+   * @param endpoint datahub endpoint
+   * @param func handle RecordEntry to String
+   */
   def createStream(
       jssc: JavaStreamingContext,
       projectName: String,
@@ -217,10 +300,34 @@ class DatahubUtilsHelper {
       endpoint: String,
       func: RecordEntry => String,
       storageLevel: StorageLevel): DStream[Array[Byte]] = {
-    DatahubUtils.createStream(jssc.ssc, projectName, topicName, subId, accessKeyId, accessKeySecret, endpoint, func, storageLevel)
+    DatahubUtils.createStream(
+      jssc.ssc,
+      projectName,
+      topicName,
+      subId,
+      accessKeyId,
+      accessKeySecret,
+      endpoint,
+      func,
+      storageLevel)
   }
 
-  def createDirectStream(jssc: JavaStreamingContext,
+  /**
+   * :: Experimental ::
+   * Java constructor for a DStream where
+   * each datahub shard correspond to a RDD partition.
+   * @param project datahub project name
+   * @param topic datahub topic name
+   * @param subId datahub subscription id
+   * @param accessId aliyun access key id
+   * @param accessKey aliyun access key secret
+   * @param endpoint datahub endpoint
+   * @param func handle RecordEntry to String
+   * @param mode datahub cursor type
+   * @param zkParam Zookeeper configuration
+   */
+  def createDirectStream(
+      jssc: JavaStreamingContext,
       endpoint: String,
       project: String,
       topic: String,
@@ -233,7 +340,21 @@ class DatahubUtilsHelper {
     DatahubUtils.createDirectStream(jssc.ssc, endpoint, project, topic, subId, accessId, accessKey, func, mode, zkParam)
   }
 
-  def createDirectStream(jssc: JavaStreamingContext,
+  /**
+   * :: Experimental ::
+   * Java constructor for a DStream where
+   * each datahub shard correspond to a RDD partition.
+   * @param project datahub project name
+   * @param topic datahub topic name
+   * @param subId datahub subscription id
+   * @param accessId aliyun access key id
+   * @param accessKey aliyun access key secret
+   * @param endpoint datahub endpoint
+   * @param func handle RecordEntry to String
+   * @param zkParam Zookeeper configuration
+   */
+  def createDirectStream(
+      jssc: JavaStreamingContext,
       endpoint: String,
       project: String,
       topic: String,

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubUtils.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubUtils.scala
@@ -17,11 +17,12 @@
 package org.apache.spark.streaming.aliyun.datahub
 
 import com.aliyun.datahub.auth.AliyunAccount
-import com.aliyun.datahub.{DatahubClient, DatahubConfiguration}
+import com.aliyun.datahub.model.GetCursorRequest.CursorType
 import com.aliyun.datahub.model.RecordEntry
+import com.aliyun.datahub.{DatahubClient, DatahubConfiguration}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.StreamingContext
-import org.apache.spark.streaming.dstream.{DStream, ReceiverInputDStream}
+import org.apache.spark.streaming.dstream.DStream
 
 object DatahubUtils {
   def createStream(
@@ -79,5 +80,50 @@ object DatahubUtils {
     }
 
     dStream
+  }
+
+  def createDirectStream(ssc: StreamingContext,
+      endpoint: String,
+      project: String,
+      topic: String,
+      subId: String,
+      accessId: String,
+      accessKey: String,
+      func: RecordEntry => String,
+      mode: CursorType,
+      zkParam: Map[String, String]): DStream[Array[Byte]] = {
+    ssc.withNamedScope("datahub direct stream") {
+      new DirectDatahubInputDStream(ssc,
+        endpoint,
+        project,
+        topic,
+        subId,
+        accessId,
+        accessKey,
+        func,
+        mode,
+        zkParam)
+    }
+  }
+
+  def createDirectStream(ssc: StreamingContext,
+      endpoint: String,
+      project: String,
+      topic: String,
+      subId: String,
+      accessId: String,
+      accessKey: String,
+      func: RecordEntry => String,
+      zkParam: Map[String, String]): DStream[Array[Byte]] = {
+    createDirectStream(ssc,
+      endpoint,
+      project,
+      topic,
+      subId,
+      accessId,
+      accessKey,
+      func,
+      CursorType.LATEST,
+      zkParam)
   }
 }

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubUtils.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubUtils.scala
@@ -136,6 +136,8 @@ object DatahubUtils {
    * :: Experimental ::
    * Scala constructor for a DStream where
    * each datahub shard correspond to a RDD partition.
+   * The Spark configuration spark.streaming.datahub.maxRatePerShard sets
+   * max number of records per shard every second, 1000 by default.
    * @param project datahub project name
    * @param topic datahub topic name
    * @param subId datahub subscription id
@@ -190,6 +192,8 @@ object DatahubUtils {
    * :: Experimental ::
    * Scala constructor for a DStream where
    * each datahub shard correspond to a RDD partition.
+   * The Spark configuration spark.streaming.datahub.maxRatePerShard sets
+   * max number of records per shard every second.
    * @param project datahub project name
    * @param topic datahub topic name
    * @param subId datahub subscription id
@@ -316,6 +320,8 @@ class DatahubUtilsHelper {
    * :: Experimental ::
    * Java constructor for a DStream where
    * each datahub shard correspond to a RDD partition.
+   * The Spark configuration spark.streaming.datahub.maxRatePerShard sets
+   * max number of records per shard every second.
    * @param project datahub project name
    * @param topic datahub topic name
    * @param subId datahub subscription id
@@ -344,6 +350,8 @@ class DatahubUtilsHelper {
    * :: Experimental ::
    * Java constructor for a DStream where
    * each datahub shard correspond to a RDD partition.
+   * The Spark configuration spark.streaming.datahub.maxRatePerShard sets
+   * max number of records per shard every second.
    * @param project datahub project name
    * @param topic datahub topic name
    * @param subId datahub subscription id

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubWorker.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DatahubWorker.scala
@@ -16,12 +16,12 @@
  */
 package org.apache.spark.streaming.aliyun.datahub
 
-import com.aliyun.datahub.exception.{OffsetResetedException, OffsetSessionChangedException, SubscriptionOfflineException}
-
 import scala.collection.JavaConversions._
+
+import com.aliyun.datahub.DatahubConfiguration
+import com.aliyun.datahub.exception.OffsetResetedException
 import com.aliyun.datahub.model.GetCursorRequest.CursorType
 import com.aliyun.datahub.model.RecordEntry
-import com.aliyun.datahub.DatahubConfiguration
 import org.apache.spark.internal.Logging
 
 class DatahubWorker(projectName: String, topicName: String, shardId: String, subId: String,

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DirectDatahubInputDStream.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DirectDatahubInputDStream.scala
@@ -41,7 +41,7 @@ import org.apache.spark.streaming.{StreamingContext, Time}
 import org.apache.spark.util.Utils
 
 class DirectDatahubInputDStream(
-    @transient _ssc: StreamingContext,
+    _ssc: StreamingContext,
     endpoint: String,
     project: String,
     topic: String,
@@ -184,7 +184,7 @@ class DirectDatahubInputDStream(
         })
 
         lastJobTime = validTime.milliseconds
-        new DatahubRDD(_ssc.sc, _ssc.graph.batchDuration.milliseconds, endpoint, project, topic, subId, accessId,
+        new DatahubRDD(ssc.sc, ssc.graph.batchDuration.milliseconds, endpoint, project, topic, subId, accessId,
           accessKey, func, shardOffsets, zkParam, checkpointDir)
       } else {
         return None

--- a/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DirectDatahubInputDStream.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/streaming/aliyun/datahub/DirectDatahubInputDStream.scala
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.aliyun.datahub
+
+import java.io.{IOException, ObjectInputStream, UnsupportedEncodingException}
+import java.nio.charset.StandardCharsets
+
+import com.aliyun.datahub.DatahubConfiguration
+import com.aliyun.datahub.auth.AliyunAccount
+import com.aliyun.datahub.model.GetCursorRequest.CursorType
+import com.aliyun.datahub.model.{OffsetContext, RecordEntry, ShardState}
+import org.I0Itec.zkclient.ZkClient
+import org.I0Itec.zkclient.exception.ZkNoNodeException
+import org.I0Itec.zkclient.serialize.ZkSerializer
+import org.apache.hadoop.fs.Path
+import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.streaming.dstream.{DStreamCheckpointData, InputDStream}
+import org.apache.spark.streaming.scheduler.StreamInputInfo
+import org.apache.spark.streaming.{StreamingContext, Time}
+import org.apache.spark.util.Utils
+
+import scala.collection.mutable.{ArrayBuffer, HashMap}
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
+class DirectDatahubInputDStream(
+    @transient _ssc: StreamingContext,
+    endpoint: String,
+    project: String,
+    topic: String,
+    subId: String,
+    accessId: String,
+    accessKey: String,
+    func: RecordEntry => String,
+    mode: CursorType,
+    zkParam: Map[String, String]) extends InputDStream[Array[Byte]](_ssc) with CanCommitOffsets {
+  @transient private var datahubClient: DatahubClientAgent = null
+  @transient private var zkClient: ZkClient = null
+  private var checkpointDir: String = null
+  @transient private var restart = false
+  @transient private var commitLock = new Object
+  private var doCommit = false
+  private var restartTime = -1L
+  private var lastJobTime = -1L
+  private var readOnlyShardCache = new mutable.HashMap[String, Long]()
+
+  override def start(): Unit = {
+    datahubClient = new DatahubClientAgent(new DatahubConfiguration(new AliyunAccount(accessId, accessKey), endpoint))
+    val zkServers = zkParam.getOrElse("zookeeper.connect", "localhost:2181")
+    val sessionTimeout = zkParam.getOrElse("zookeeper.session.timeout.ms", "6000").toInt
+    val connectionTimeout = zkParam.getOrElse("zookeeper.connection.timeout.ms", sessionTimeout.toString).toInt
+    zkClient = new ZkClient(zkServers, sessionTimeout, connectionTimeout)
+    zkClient.setZkSerializer(new ZkSerializer {
+      override def serialize(data: scala.Any): Array[Byte] = {
+        try {
+          data.asInstanceOf[String].getBytes(StandardCharsets.UTF_8)
+        } catch {
+          case e: UnsupportedEncodingException =>
+            logError("Fail to write data to Zookeeper.", e)
+            null
+        }
+      }
+
+      override def deserialize(bytes: Array[Byte]): AnyRef = {
+        if (bytes == null) {
+          return null
+        }
+        try {
+          new String(bytes, StandardCharsets.UTF_8)
+        } catch {
+          case e: UnsupportedEncodingException =>
+            logError("Fail to fetch data from Zookeeper.", e)
+            null
+        }
+      }
+    })
+
+    checkpointDir = new Path(ssc.checkpointDir).toUri.getPath
+    if (!zkClient.exists(s"$checkpointDir/datahub")) {
+      zkClient.createPersistent(s"$checkpointDir/datahub/consume/$project/$topic", true)
+      zkClient.createPersistent(s"$checkpointDir/datahub/commit/$project/$topic", true)
+    }
+
+    val initial = if(zkClient.exists(s"$checkpointDir/datahub/consume/$project/$topic/$subId")) {
+      zkClient.getChildren(s"$checkpointDir/datahub/consume/$project/$topic/$subId").toArray()
+    } else Array.empty[String]
+    val shards = datahubClient.listShards(project, topic).getShards
+
+    val diff = shards.map(_.getShardId).diff(initial)
+    diff.foreach(shardId => {
+      val oldestCursor = fetchCursorFormDatahub(shardId)
+      val oldestOffset = new OffsetContext.Offset(oldestCursor.getSequence, oldestCursor.getRecordTime)
+      DirectDatahubInputDStream.writeDataToZk(zkClient, s"$checkpointDir/datahub/consume/$project/$topic/$subId/$shardId",
+        JacksonParser.toJsonNode(oldestOffset).toString)
+    })
+  }
+
+  override def stop(): Unit ={
+    if (zkClient != null) {
+      zkClient.close()
+      zkClient = null
+    }
+  }
+
+  override def compute(validTime: Time): Option[RDD[Array[Byte]]] = {
+    if (restartTime == -1) {
+      val zeroTime = graph.zeroTime.milliseconds
+      val gap = System.currentTimeMillis() -  zeroTime
+      val duration = graph.batchDuration.milliseconds
+      restartTime = (math.floor(gap / duration).toLong + 1) * duration + zeroTime
+    }
+
+    commitLock.synchronized {
+      val lastFailed = if (doCommit) {
+        false
+      } else {
+        val pending = ssc.scheduler.getPendingTimes().exists(time => time.milliseconds == lastJobTime)
+        if (pending) {
+          false
+        } else {
+          true
+        }
+      }
+
+      val shardOffsets: ArrayBuffer[(String, String, String)] = new ArrayBuffer()
+      val rdd = if (validTime.milliseconds > restartTime && (doCommit || lastFailed)) {
+        if (restart || lastFailed) {
+          restart = false
+        } else {
+          commitAll()
+        }
+
+        val result = datahubClient.listShards(project, topic)
+        result.getShards.foreach(shardEntry => {
+          val shardId = shardEntry.getShardId
+          if (readOnlyShardCache.contains(shardId)) {
+            logDebug(s"Get no record in read only shard[$shardId], do nothing")
+          } else {
+            var startOffset: OffsetContext.Offset = null
+            try {
+              val consume: String = zkClient.readData(s"$checkpointDir/datahub/consume/$project/$topic/$subId/$shardId")
+              startOffset = JacksonParser.getOffset(consume)
+            } catch {
+              case _:ZkNoNodeException =>
+                logWarning("Fail to get start offset form zookeeper, retry with datahub")
+                val cursorResult = fetchCursorFormDatahub(shardId)
+                startOffset = new OffsetContext.Offset(cursorResult.getSequence, cursorResult.getRecordTime)
+            }
+
+            val latestCursor = datahubClient.getCursor(project, topic, shardId, CursorType.LATEST)
+            val endOffset = new OffsetContext.Offset(latestCursor.getSequence, latestCursor.getRecordTime)
+            if (startOffset.getSequence <= endOffset.getSequence) {
+              val so = (shardId, JacksonParser.toJsonNode(startOffset).toString, JacksonParser.toJsonNode(endOffset).toString)
+              shardOffsets += so
+            }
+            if (ShardState.CLOSED.equals(shardEntry.getState) && latestCursor.getSequence >= endOffset.getSequence) {
+              readOnlyShardCache.put(shardId, endOffset.getSequence)
+            }
+          }
+        })
+
+        lastJobTime = validTime.milliseconds
+        new DatahubRDD(_ssc.sc, _ssc.graph.batchDuration.milliseconds, endpoint, project, topic, subId, accessId,
+          accessKey, func, shardOffsets, zkParam, checkpointDir)
+      } else {
+        return None
+      }
+
+      val description = shardOffsets.map { p =>
+        val offset = "offset: [ %1$-30s to %2$-30s ]".format(p._2, p._3)
+        s"shardId: ${p._1}\t $offset"
+      }.mkString("\n")
+      val metadata = Map(StreamInputInfo.METADATA_KEY_DESCRIPTION -> description)
+      if (storageLevel != StorageLevel.NONE && rdd.isInstanceOf[DatahubRDD]) {
+        // If storageLevel is not `StorageLevel.NONE`, we need to persist rdd before `count()` to
+        // to count the number of records to avoid refetching data from loghub.
+        rdd.persist(storageLevel)
+        logDebug(s"Persisting RDD ${rdd.id} for time $validTime to $storageLevel")
+      }
+      val inputInfo = StreamInputInfo(id, rdd.count, metadata)
+      ssc.scheduler.inputInfoTracker.reportInfo(validTime, inputInfo)
+      Some(rdd)
+    }
+  }
+
+  override private[streaming] def name = s"datahub direct stream[$id]"
+
+  override def commitAsync(): Unit = {
+    commitLock.synchronized {
+      doCommit = true
+    }
+  }
+
+  private def commitAll(): Unit = {
+    if (doCommit) {
+      try {
+        val shards = zkClient.getChildren(s"$checkpointDir/datahub/commit/$project/$topic/$subId")
+        shards.foreach(shard => {
+          if (!readOnlyShardCache.contains(shard)) {
+            val commit: String = zkClient.readData(s"$checkpointDir/datahub/commit/$project/$topic/$subId/$shard")
+            val offset = JacksonParser.getOffset(commit)
+            val currentOffsetContext = datahubClient.initOffsetContext(project, topic, subId, shard)
+            currentOffsetContext.setOffset(offset)
+            datahubClient.commitOffset(currentOffsetContext)
+            DirectDatahubInputDStream.writeDataToZk(zkClient, s"$checkpointDir/datahub/consume/$project/$topic/$subId/$shard",
+              JacksonParser.toJsonNode(offset).toString)
+          }
+        })
+        doCommit = false
+      } catch {
+        case _: ZkNoNodeException => {
+          logWarning("If this is the first time to run, it is fine to not find any commit data in " +
+            "zookeeper.")
+          doCommit = false
+        }
+      }
+    }
+  }
+
+  private def fetchCursorFormDatahub(shardId: String) = {
+    val offsetContext = datahubClient.initOffsetContext(project, topic, subId, shardId)
+    if (offsetContext.hasOffset) {
+      datahubClient.getNextOffsetCursor(offsetContext)
+    } else {
+      mode match {
+        case CursorType.OLDEST => datahubClient.getCursor(project, topic, shardId, CursorType.OLDEST)
+        case CursorType.LATEST => datahubClient.getCursor(project, topic, shardId, CursorType.LATEST)
+        case CursorType.SEQUENCE => datahubClient.getCursor(project, topic, shardId, CursorType.SEQUENCE)
+        case CursorType.SYSTEM_TIME => datahubClient.getCursor(project, topic, shardId, CursorType.SYSTEM_TIME)
+      }
+    }
+  }
+
+  @throws(classOf[IOException])
+  private def readObject(ois: ObjectInputStream): Unit = Utils.tryOrIOException {
+    // TODO: move following logic to proper restart code path.
+    this.synchronized {
+      logDebug(s"${this.getClass.getSimpleName}.readObject used")
+      ois.defaultReadObject()
+      generatedRDDs = new HashMap[Time, RDD[Array[Byte]]]()
+      readOnlyShardCache = new mutable.HashMap[String, Long]()
+      commitLock = new Object()
+      val zkServers = zkParam.getOrElse("zookeeper.connect", "localhost:2181")
+      val sessionTimeout = zkParam.getOrElse("zookeeper.session.timeout.ms", "6000").toInt
+      val connectionTimeout = zkParam.getOrElse("zookeeper.connection.timeout.ms", sessionTimeout.toString).toInt
+      zkClient = new ZkClient(zkServers, sessionTimeout, connectionTimeout)
+      zkClient.setZkSerializer(new ZkSerializer() {
+        override def serialize(data: scala.Any): Array[Byte] = {
+          try {
+            data.asInstanceOf[String].getBytes("UTF-8")
+          } catch {
+            case e: UnsupportedEncodingException =>
+              null
+          }
+        }
+
+        override def deserialize(bytes: Array[Byte]): AnyRef = {
+          if (bytes == null) {
+            return null
+          }
+          try {
+            new String(bytes, "UTF-8")
+          } catch {
+            case _: UnsupportedEncodingException =>
+              null
+          }
+        }
+      })
+
+      datahubClient = new DatahubClientAgent(new DatahubConfiguration(new AliyunAccount(accessId, accessKey), endpoint))
+      restartTime = -1L
+      restart = true
+    }
+  }
+
+  private class DirectDatahubInputDStreamCheckpointData extends DStreamCheckpointData(this) {
+    override def update(time: Time): Unit = {}
+
+    override def cleanup(time: Time): Unit = {}
+
+    override def restore(): Unit = {}
+
+    override def finalize(): Unit = {
+      super.finalize()
+      stop()
+    }
+  }
+}
+
+object DirectDatahubInputDStream {
+  private def writeDataToZk(zkClient: ZkClient, path: String, data: String) = {
+    if (!zkClient.exists(path)) {
+      zkClient.createPersistent(path, true)
+    }
+    zkClient.writeData(path, data)
+  }
+}

--- a/emr-logservice/src/main/scala/org/apache/spark/streaming/aliyun/logservice/CanCommitOffsets.scala
+++ b/emr-logservice/src/main/scala/org/apache/spark/streaming/aliyun/logservice/CanCommitOffsets.scala
@@ -21,10 +21,10 @@ import org.apache.spark.annotation.Experimental
 @Experimental
 trait CanCommitOffsets {
   /**
-    *  :: Experimental ::
-    * Queue up offset ranges for commit to Loghub at a future time.  Threadsafe.
-    * This is only needed if you intend to store offsets in Loghub, instead of your own store.
-    */
+   *  :: Experimental ::
+   * Queue up offset ranges for commit to Loghub at a future time.  Threadsafe.
+   * This is only needed if you intend to store offsets in Loghub, instead of your own store.
+   */
   @Experimental
   def commitAsync(): Unit
 }

--- a/emr-logservice/src/main/scala/org/apache/spark/streaming/aliyun/logservice/DirectLoghubInputDStream.scala
+++ b/emr-logservice/src/main/scala/org/apache/spark/streaming/aliyun/logservice/DirectLoghubInputDStream.scala
@@ -358,7 +358,7 @@ class DirectLoghubInputDStream(
             }
           } catch {
             case e1: LogException =>
-              new LogHubClientWorkerException("error occurs when get consumer group, errorCode: " +
+              throw new LogHubClientWorkerException("error occurs when get consumer group, errorCode: " +
                 e1.GetErrorCode + ", errorMessage: " + e1.GetErrorMessage)
           }
         } else {

--- a/examples/src/main/scala/com/aliyun/emr/examples/streaming/TestDatahub.scala
+++ b/examples/src/main/scala/com/aliyun/emr/examples/streaming/TestDatahub.scala
@@ -61,7 +61,7 @@ object TestDatahub {
           accessKeySecret,
           endpoint,
           shardId,
-          read,
+          read(_),
           StorageLevel.MEMORY_AND_DISK)
       } else {
         datahubStream = DatahubUtils.createStream(
@@ -72,7 +72,7 @@ object TestDatahub {
           accessKeyId,
           accessKeySecret,
           endpoint,
-          read,
+          read(_),
           StorageLevel.MEMORY_AND_DISK)
       }
 

--- a/examples/src/main/scala/com/aliyun/emr/examples/streaming/TestDirectDatahub.scala
+++ b/examples/src/main/scala/com/aliyun/emr/examples/streaming/TestDirectDatahub.scala
@@ -30,7 +30,7 @@ object TestDirectDatahub {
       val sc = new SparkContext(new SparkConf().setAppName("test-direct-datahub"))
       sc.setLogLevel("ERROR")
       val ssc = new StreamingContext(sc, Duration(duration))
-      val dstream = DatahubUtils.createDirectStream(ssc, endpoint, project, topic, subId, accessId, accessKey, read, zkParam)
+      val dstream = DatahubUtils.createDirectStream(ssc, endpoint, project, topic, subId, accessId, accessKey, read(_), zkParam)
 
       dstream.checkpoint(Duration(duration)).foreachRDD(rdd => {
         println(s"count:${rdd.count()}")

--- a/examples/src/main/scala/com/aliyun/emr/examples/streaming/TestDirectDatahub.scala
+++ b/examples/src/main/scala/com/aliyun/emr/examples/streaming/TestDirectDatahub.scala
@@ -44,7 +44,6 @@ object TestDirectDatahub {
 
     def getStreamingContext(): StreamingContext = {
       val sc = new SparkContext(new SparkConf().setAppName("test-direct-datahub"))
-      sc.setLogLevel("ERROR")
       val ssc = new StreamingContext(sc, Duration(duration))
       val dstream = DatahubUtils.createDirectStream(
         ssc,

--- a/examples/src/main/scala/com/aliyun/emr/examples/streaming/TestDirectDatahub.scala
+++ b/examples/src/main/scala/com/aliyun/emr/examples/streaming/TestDirectDatahub.scala
@@ -1,9 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.aliyun.emr.examples.streaming
 
 import com.aliyun.datahub.model.RecordEntry
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.streaming.{Duration, StreamingContext}
-import org.apache.spark.streaming.aliyun.datahub.{DatahubUtils, DirectDatahubInputDStream}
+import org.apache.spark.streaming.aliyun.datahub.{CanCommitOffsets, DatahubUtils, DirectDatahubInputDStream}
 
 object TestDirectDatahub {
   def main(args: Array[String]): Unit = {
@@ -30,11 +46,20 @@ object TestDirectDatahub {
       val sc = new SparkContext(new SparkConf().setAppName("test-direct-datahub"))
       sc.setLogLevel("ERROR")
       val ssc = new StreamingContext(sc, Duration(duration))
-      val dstream = DatahubUtils.createDirectStream(ssc, endpoint, project, topic, subId, accessId, accessKey, read(_), zkParam)
+      val dstream = DatahubUtils.createDirectStream(
+        ssc,
+        endpoint,
+        project,
+        topic,
+        subId,
+        accessId,
+        accessKey,
+        read(_),
+        zkParam)
 
       dstream.checkpoint(Duration(duration)).foreachRDD(rdd => {
         println(s"count:${rdd.count()}")
-        dstream.asInstanceOf[DirectDatahubInputDStream].commitAsync()
+        dstream.asInstanceOf[CanCommitOffsets].commitAsync()
       })
       ssc.checkpoint(checkpointDir)
       ssc

--- a/examples/src/main/scala/com/aliyun/emr/examples/streaming/TestDirectDatahub.scala
+++ b/examples/src/main/scala/com/aliyun/emr/examples/streaming/TestDirectDatahub.scala
@@ -1,0 +1,52 @@
+package com.aliyun.emr.examples.streaming
+
+import com.aliyun.datahub.model.RecordEntry
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.streaming.{Duration, StreamingContext}
+import org.apache.spark.streaming.aliyun.datahub.{DatahubUtils, DirectDatahubInputDStream}
+
+object TestDirectDatahub {
+  def main(args: Array[String]): Unit = {
+    if (args.length < 7) {
+      println(
+        """
+          |Usage: TestDirectDatahub endpoint project topic subId accessId accessKey duration [zookeeper-host:port]
+        """.stripMargin)
+      sys.exit(1)
+    }
+    val endpoint = args(0)
+    val project = args(1)
+    val topic = args(2)
+    val subId = args(3)
+    val accessId = args(4)
+    val accessKey = args(5)
+    val duration = args(6).toLong * 1000
+    val zkServer = if (args.length > 7 ) args(7) else "localhost:2181"
+
+    val checkpointDir = "/tmp/datahub/checkpoint/test-direct-datahub"
+    val zkParam = Map("zookeeper.connect" -> zkServer)
+
+    def getStreamingContext(): StreamingContext = {
+      val sc = new SparkContext(new SparkConf().setAppName("test-direct-datahub"))
+      sc.setLogLevel("ERROR")
+      val ssc = new StreamingContext(sc, Duration(duration))
+      val dstream = DatahubUtils.createDirectStream(ssc, endpoint, project, topic, subId, accessId, accessKey, read, zkParam)
+
+      dstream.checkpoint(Duration(duration)).foreachRDD(rdd => {
+        println(s"count:${rdd.count()}")
+        dstream.asInstanceOf[DirectDatahubInputDStream].commitAsync()
+      })
+      ssc.checkpoint(checkpointDir)
+      ssc
+    }
+
+    val ssc = StreamingContext.getOrCreate(checkpointDir, getStreamingContext)
+    ssc.start()
+    ssc.awaitTermination()
+  }
+
+  def read(recordEntry: RecordEntry): String = {
+    recordEntry.toJsonNode.toString
+  }
+
+}

--- a/examples/src/main/scala/com/aliyun/emr/examples/streaming/TestDirectLoghub.scala
+++ b/examples/src/main/scala/com/aliyun/emr/examples/streaming/TestDirectLoghub.scala
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.aliyun.emr.examples.streaming
 
 import com.aliyun.openservices.loghub.client.config.LogHubCursorPosition

--- a/examples/src/main/scala/com/aliyun/emr/examples/streaming/UnionDirectDatahub.scala
+++ b/examples/src/main/scala/com/aliyun/emr/examples/streaming/UnionDirectDatahub.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.aliyun.emr.examples.streaming
+
+import com.aliyun.datahub.model.RecordEntry
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.streaming.{Duration, StreamingContext}
+import org.apache.spark.streaming.aliyun.datahub.{CanCommitOffsets, DatahubUtils, DirectDatahubInputDStream}
+
+object TestDirectDatahub {
+  def main(args: Array[String]): Unit = {
+    if (args.length < 7) {
+      println(
+        """
+          |Usage: TestDirectDatahub endpoint project topic subId accessId accessKey duration [zookeeper-host:port]
+        """.stripMargin)
+      sys.exit(1)
+    }
+    val endpoint = args(0)
+    val project = args(1)
+    val topic = args(2)
+    val subId = args(3)
+    val accessId = args(4)
+    val accessKey = args(5)
+    val duration = args(6).toLong * 1000
+    val zkServer = if (args.length > 7 ) args(7) else "localhost:2181"
+
+    val checkpointDir = "/tmp/datahub/checkpoint/test-direct-datahub"
+    val zkParam = Map("zookeeper.connect" -> zkServer)
+
+    def getStreamingContext(): StreamingContext = {
+      val sc = new SparkContext(new SparkConf().setAppName("test-direct-datahub"))
+      val ssc = new StreamingContext(sc, Duration(duration))
+      val dstream = DatahubUtils.createDirectStream(
+        ssc,
+        endpoint,
+        project,
+        topic,
+        subId,
+        accessId,
+        accessKey,
+        read(_),
+        zkParam)
+
+      dstream.checkpoint(Duration(duration)).foreachRDD(rdd => {
+        println(s"count:${rdd.count()}")
+        dstream.asInstanceOf[CanCommitOffsets].commitAsync()
+      })
+      ssc.checkpoint(checkpointDir)
+      ssc
+    }
+
+    val ssc = StreamingContext.getOrCreate(checkpointDir, getStreamingContext)
+    ssc.start()
+    ssc.awaitTermination()
+  }
+
+  def read(recordEntry: RecordEntry): String = {
+    recordEntry.toJsonNode.toString
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. implement spark streaming direct api to datahub
2. add spark streaming datahub source java api
3. fetch oldest data when data is expired and consume offset is early

## How was this patch tested?
1. Test class:
 com.aliyun.emr.examples.streaming.TestDirectDatahub
2. Test case:
long running, no exception or error
killed by yarn and restart by spark-submit manully, not data loss and may be replicated
killed by yarn, clear checkpoint and zookeepr checkpoint path, restart by spark-submit manully, consume oldest data