### PR TITLE
Update ODPSRDD.scala

### DIFF
--- a/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/odps/datasource/ODPSRDD.scala
+++ b/emr-maxcompute/src/main/scala/org/apache/spark/aliyun/odps/datasource/ODPSRDD.scala
@@ -89,6 +89,8 @@ class ODPSRDD(
                       val value = r.getBigint(s.name)
                       if (value != null) {
                         mutableRow.setLong(idx, value)
+                      } else {
+                        mutableRow.update(idx, null)
                       }
                     case BooleanType =>
                       val value = r.getBoolean(s.name)


### PR DESCRIPTION
处理Long数据时，当value为null时，补充将mutableRow更新为null，否则在处理Long型数据时，会出现读取数据错误的情况。

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
