### PR TITLE
Add retry for internal server error

### DIFF
--- a/emr-logservice/src/main/java/org/apache/spark/streaming/aliyun/logservice/LoghubClientAgent.java
+++ b/emr-logservice/src/main/java/org/apache/spark/streaming/aliyun/logservice/LoghubClientAgent.java
@@ -109,7 +109,7 @@ public class LoghubClientAgent {
   }
 
   public ConsumerGroupUpdateCheckPointResponse UpdateCheckPoint(String project, String logStore, String consumerGroup,
-                                                                int shard, String checkpoint) throws Exception {
+      int shard, String checkpoint) throws Exception {
     int retry = 0;
     Exception currentException = null;
     long backoff = initialBackoff;
@@ -204,7 +204,7 @@ public class LoghubClientAgent {
   }
 
   public BatchGetLogResponse BatchGetLog(String project, String logStore, int shardId, int count, String cursor,
-                                         String endCursor) throws Exception {
+      String endCursor) throws Exception {
     int retry = 0;
     Exception currentException = null;
     long backoff = initialBackoff;
@@ -228,7 +228,7 @@ public class LoghubClientAgent {
   }
 
   public GetHistogramsResponse GetHistograms(String project, String logStore, int from, int to, String topic,
-                                             String query) throws Exception {
+      String query) throws Exception {
     int retry = 0;
     Exception currentException = null;
     long backoff = initialBackoff;

--- a/emr-logservice/src/main/java/org/apache/spark/streaming/aliyun/logservice/LoghubClientAgent.java
+++ b/emr-logservice/src/main/java/org/apache/spark/streaming/aliyun/logservice/LoghubClientAgent.java
@@ -29,7 +29,9 @@ import org.apache.http.conn.ConnectTimeoutException;
 public class LoghubClientAgent {
   private static final Log LOG = LogFactory.getLog(LoghubClientAgent.class);
   private Client client;
-  private int logServiceTimeoutMaxRetry = 3;
+  private int logServiceTimeoutMaxRetry = 6;
+  private long initialBackoff = 1000;
+  private long maxBackoff = 10000;
 
   public LoghubClientAgent(String endpoint, String accessId, String accessKey) {
     this.client = new Client(endpoint, accessId, accessKey);
@@ -39,12 +41,15 @@ public class LoghubClientAgent {
       throws Exception {
     int retry = 0;
     Exception currentException = null;
+    long backoff = initialBackoff;
     while (retry <= logServiceTimeoutMaxRetry) {
       try {
         return this.client.ListShard(logProject, logStore);
       } catch (LogException e) {
-        if (checkConnectionTimeoutException(e)) {
+        if (isRecoverableException(e)) {
           retry += 1;
+          Thread.sleep(backoff);
+          backoff = Math.min(backoff * 2, maxBackoff);
           currentException = e;
         } else {
           throw e;
@@ -59,13 +64,16 @@ public class LoghubClientAgent {
   public GetCursorResponse GetCursor(String project, String logStream, int shardId, Consts.CursorMode mode)
       throws Exception {
     int retry = 0;
+    long backoff = initialBackoff;
     Exception currentException = null;
     while (retry <= logServiceTimeoutMaxRetry) {
       try {
         return this.client.GetCursor(project, logStream, shardId, mode);
       } catch (LogException e) {
-        if (checkConnectionTimeoutException(e)) {
+        if (isRecoverableException(e)) {
           retry += 1;
+          Thread.sleep(backoff);
+          backoff = Math.min(backoff * 2, maxBackoff);
           currentException = e;
         } else {
           throw e;
@@ -80,12 +88,15 @@ public class LoghubClientAgent {
   public GetCursorResponse GetCursor(String project, String logStore, int shardId, long fromTime) throws Exception {
     int retry = 0;
     Exception currentException = null;
+    long backoff = initialBackoff;
     while (retry <= logServiceTimeoutMaxRetry) {
       try {
         return this.client.GetCursor(project, logStore, shardId, fromTime);
       } catch (LogException e) {
-        if (checkConnectionTimeoutException(e)) {
+        if (isRecoverableException(e)) {
           retry += 1;
+          Thread.sleep(backoff);
+          backoff = Math.min(backoff * 2, maxBackoff);
           currentException = e;
         } else {
           throw e;
@@ -98,15 +109,18 @@ public class LoghubClientAgent {
   }
 
   public ConsumerGroupUpdateCheckPointResponse UpdateCheckPoint(String project, String logStore, String consumerGroup,
-      int shard, String checkpoint) throws Exception {
+                                                                int shard, String checkpoint) throws Exception {
     int retry = 0;
     Exception currentException = null;
+    long backoff = initialBackoff;
     while (retry <= logServiceTimeoutMaxRetry) {
       try {
         return this.client.UpdateCheckPoint(project, logStore, consumerGroup, shard, checkpoint);
       } catch (LogException e) {
-        if (checkConnectionTimeoutException(e)) {
+        if (isRecoverableException(e)) {
           retry += 1;
+          Thread.sleep(backoff);
+          backoff = Math.min(backoff * 2, maxBackoff);
           currentException = e;
         } else {
           throw e;
@@ -122,12 +136,15 @@ public class LoghubClientAgent {
       throws Exception {
     int retry = 0;
     Exception currentException = null;
+    long backoff = initialBackoff;
     while (retry <= logServiceTimeoutMaxRetry) {
       try {
         return this.client.CreateConsumerGroup(project, logStore, consumerGroup);
       } catch (LogException e) {
-        if (checkConnectionTimeoutException(e)) {
+        if (isRecoverableException(e)) {
           retry += 1;
+          Thread.sleep(backoff);
+          backoff = Math.min(backoff * 2, maxBackoff);
           currentException = e;
         } else {
           throw e;
@@ -142,12 +159,15 @@ public class LoghubClientAgent {
   public ListConsumerGroupResponse ListConsumerGroup(String project, String logStore) throws Exception {
     int retry = 0;
     Exception currentException = null;
+    long backoff = initialBackoff;
     while (retry <= logServiceTimeoutMaxRetry) {
       try {
         return this.client.ListConsumerGroup(project, logStore);
       } catch (LogException e) {
-        if (checkConnectionTimeoutException(e)) {
+        if (isRecoverableException(e)) {
           retry += 1;
+          Thread.sleep(backoff);
+          backoff = Math.min(backoff * 2, maxBackoff);
           currentException = e;
         } else {
           throw e;
@@ -163,12 +183,15 @@ public class LoghubClientAgent {
       throws Exception {
     int retry = 0;
     Exception currentException = null;
+    long backoff = initialBackoff;
     while (retry <= logServiceTimeoutMaxRetry) {
       try {
         return this.client.GetCheckPoint(project, logStore, consumerGroup, shard);
       } catch (LogException e) {
-        if (checkConnectionTimeoutException(e)) {
+        if (isRecoverableException(e)) {
           retry += 1;
+          Thread.sleep(backoff);
+          backoff = Math.min(backoff * 2, maxBackoff);
           currentException = e;
         } else {
           throw e;
@@ -181,15 +204,18 @@ public class LoghubClientAgent {
   }
 
   public BatchGetLogResponse BatchGetLog(String project, String logStore, int shardId, int count, String cursor,
-      String endCursor) throws Exception {
+                                         String endCursor) throws Exception {
     int retry = 0;
     Exception currentException = null;
+    long backoff = initialBackoff;
     while (retry <= logServiceTimeoutMaxRetry) {
       try {
         return this.client.BatchGetLog(project, logStore, shardId, count, cursor, endCursor);
       } catch (LogException e) {
-        if (checkConnectionTimeoutException(e)) {
+        if (isRecoverableException(e)) {
           retry += 1;
+          Thread.sleep(backoff);
+          backoff = Math.min(backoff * 2, maxBackoff);
           currentException = e;
         } else {
           throw e;
@@ -202,15 +228,18 @@ public class LoghubClientAgent {
   }
 
   public GetHistogramsResponse GetHistograms(String project, String logStore, int from, int to, String topic,
-      String query) throws Exception {
+                                             String query) throws Exception {
     int retry = 0;
     Exception currentException = null;
+    long backoff = initialBackoff;
     while (retry <= logServiceTimeoutMaxRetry) {
       try {
         return this.client.GetHistograms(project, logStore, from, to, topic, query);
       } catch (LogException e) {
-        if (checkConnectionTimeoutException(e)) {
+        if (isRecoverableException(e)) {
           retry += 1;
+          Thread.sleep(backoff);
+          backoff = Math.min(backoff * 2, maxBackoff);
           currentException = e;
         } else {
           if (e.GetErrorCode().equals("IndexConfigNotExist")) {
@@ -229,12 +258,15 @@ public class LoghubClientAgent {
       throws Exception {
     int retry = 0;
     Exception currentException = null;
+    long backoff = initialBackoff;
     while (retry <= logServiceTimeoutMaxRetry) {
       try {
         return this.client.GetCursorTime(project, logStore, shardId, cursor);
       } catch (LogException e) {
-        if (checkConnectionTimeoutException(e)) {
+        if (isRecoverableException(e)) {
           retry += 1;
+          Thread.sleep(backoff);
+          backoff = Math.min(backoff * 2, maxBackoff);
           currentException = e;
         } else {
           throw e;
@@ -246,9 +278,13 @@ public class LoghubClientAgent {
     throw currentException;
   }
 
-  private boolean checkConnectionTimeoutException(LogException e) {
+  private static boolean checkConnectionTimeoutException(LogException e) {
     return e.getCause() != null
         && e.getCause().getCause() != null
         && e.getCause().getCause() instanceof ConnectTimeoutException;
+  }
+
+  private static boolean isRecoverableException(LogException ex) {
+    return checkConnectionTimeoutException(ex) || ex.GetHttpCode() >= 500;
   }
 }

--- a/emr-logservice/src/main/java/org/apache/spark/streaming/aliyun/logservice/LoghubClientAgent.java
+++ b/emr-logservice/src/main/java/org/apache/spark/streaming/aliyun/logservice/LoghubClientAgent.java
@@ -29,7 +29,7 @@ import org.apache.http.conn.ConnectTimeoutException;
 public class LoghubClientAgent {
   private static final Log LOG = LogFactory.getLog(LoghubClientAgent.class);
   private Client client;
-  private int logServiceTimeoutMaxRetry = 6;
+  private int maxRetry = 6;
   private long initialBackoff = 1000;
   private long maxBackoff = 10000;
 
@@ -42,11 +42,11 @@ public class LoghubClientAgent {
     int retry = 0;
     Exception currentException = null;
     long backoff = initialBackoff;
-    while (retry <= logServiceTimeoutMaxRetry) {
+    while (retry <= maxRetry) {
       try {
         return this.client.ListShard(logProject, logStore);
       } catch (LogException e) {
-        if (isRecoverableException(e)) {
+        if (shouldRetry(e, retry)) {
           retry += 1;
           Thread.sleep(backoff);
           backoff = Math.min(backoff * 2, maxBackoff);
@@ -56,7 +56,7 @@ public class LoghubClientAgent {
         }
       }
     }
-    LOG.error("reconnect to log-service exceed max retry times[" + logServiceTimeoutMaxRetry + "].");
+    LOG.error("reconnect to log-service exceed max retry times[" + maxRetry + "].");
     assert (currentException != null);
     throw currentException;
   }
@@ -66,11 +66,11 @@ public class LoghubClientAgent {
     int retry = 0;
     long backoff = initialBackoff;
     Exception currentException = null;
-    while (retry <= logServiceTimeoutMaxRetry) {
+    while (retry <= maxRetry) {
       try {
         return this.client.GetCursor(project, logStream, shardId, mode);
       } catch (LogException e) {
-        if (isRecoverableException(e)) {
+        if (shouldRetry(e, retry)) {
           retry += 1;
           Thread.sleep(backoff);
           backoff = Math.min(backoff * 2, maxBackoff);
@@ -80,7 +80,7 @@ public class LoghubClientAgent {
         }
       }
     }
-    LOG.error("reconnect to log-service exceed max retry times[" + logServiceTimeoutMaxRetry + "].");
+    LOG.error("reconnect to log-service exceed max retry times[" + maxRetry + "].");
     assert (currentException != null);
     throw currentException;
   }
@@ -89,11 +89,11 @@ public class LoghubClientAgent {
     int retry = 0;
     Exception currentException = null;
     long backoff = initialBackoff;
-    while (retry <= logServiceTimeoutMaxRetry) {
+    while (retry <= maxRetry) {
       try {
         return this.client.GetCursor(project, logStore, shardId, fromTime);
       } catch (LogException e) {
-        if (isRecoverableException(e)) {
+        if (shouldRetry(e, retry)) {
           retry += 1;
           Thread.sleep(backoff);
           backoff = Math.min(backoff * 2, maxBackoff);
@@ -103,7 +103,7 @@ public class LoghubClientAgent {
         }
       }
     }
-    LOG.error("reconnect to log-service exceed max retry times[" + logServiceTimeoutMaxRetry + "].");
+    LOG.error("reconnect to log-service exceed max retry times[" + maxRetry + "].");
     assert (currentException != null);
     throw currentException;
   }
@@ -113,11 +113,11 @@ public class LoghubClientAgent {
     int retry = 0;
     Exception currentException = null;
     long backoff = initialBackoff;
-    while (retry <= logServiceTimeoutMaxRetry) {
+    while (retry <= maxRetry) {
       try {
         return this.client.UpdateCheckPoint(project, logStore, consumerGroup, shard, checkpoint);
       } catch (LogException e) {
-        if (isRecoverableException(e)) {
+        if (shouldRetry(e, retry)) {
           retry += 1;
           Thread.sleep(backoff);
           backoff = Math.min(backoff * 2, maxBackoff);
@@ -127,7 +127,7 @@ public class LoghubClientAgent {
         }
       }
     }
-    LOG.error("reconnect to log-service exceed max retry times[" + logServiceTimeoutMaxRetry + "].");
+    LOG.error("reconnect to log-service exceed max retry times[" + maxRetry + "].");
     assert (currentException != null);
     throw currentException;
   }
@@ -137,11 +137,11 @@ public class LoghubClientAgent {
     int retry = 0;
     Exception currentException = null;
     long backoff = initialBackoff;
-    while (retry <= logServiceTimeoutMaxRetry) {
+    while (retry <= maxRetry) {
       try {
         return this.client.CreateConsumerGroup(project, logStore, consumerGroup);
       } catch (LogException e) {
-        if (isRecoverableException(e)) {
+        if (shouldRetry(e, retry)) {
           retry += 1;
           Thread.sleep(backoff);
           backoff = Math.min(backoff * 2, maxBackoff);
@@ -151,7 +151,7 @@ public class LoghubClientAgent {
         }
       }
     }
-    LOG.error("reconnect to log-service exceed max retry times[" + logServiceTimeoutMaxRetry + "].");
+    LOG.error("reconnect to log-service exceed max retry times[" + maxRetry + "].");
     assert (currentException != null);
     throw currentException;
   }
@@ -160,11 +160,11 @@ public class LoghubClientAgent {
     int retry = 0;
     Exception currentException = null;
     long backoff = initialBackoff;
-    while (retry <= logServiceTimeoutMaxRetry) {
+    while (retry <= maxRetry) {
       try {
         return this.client.ListConsumerGroup(project, logStore);
       } catch (LogException e) {
-        if (isRecoverableException(e)) {
+        if (shouldRetry(e, retry)) {
           retry += 1;
           Thread.sleep(backoff);
           backoff = Math.min(backoff * 2, maxBackoff);
@@ -174,7 +174,7 @@ public class LoghubClientAgent {
         }
       }
     }
-    LOG.error("reconnect to log-service exceed max retry times[" + logServiceTimeoutMaxRetry + "].");
+    LOG.error("reconnect to log-service exceed max retry times[" + maxRetry + "].");
     assert (currentException != null);
     throw currentException;
   }
@@ -184,11 +184,11 @@ public class LoghubClientAgent {
     int retry = 0;
     Exception currentException = null;
     long backoff = initialBackoff;
-    while (retry <= logServiceTimeoutMaxRetry) {
+    while (retry <= maxRetry) {
       try {
         return this.client.GetCheckPoint(project, logStore, consumerGroup, shard);
       } catch (LogException e) {
-        if (isRecoverableException(e)) {
+        if (shouldRetry(e, retry)) {
           retry += 1;
           Thread.sleep(backoff);
           backoff = Math.min(backoff * 2, maxBackoff);
@@ -198,7 +198,7 @@ public class LoghubClientAgent {
         }
       }
     }
-    LOG.error("reconnect to log-service exceed max retry times[" + logServiceTimeoutMaxRetry + "].");
+    LOG.error("reconnect to log-service exceed max retry times[" + maxRetry + "].");
     assert (currentException != null);
     throw currentException;
   }
@@ -208,11 +208,11 @@ public class LoghubClientAgent {
     int retry = 0;
     Exception currentException = null;
     long backoff = initialBackoff;
-    while (retry <= logServiceTimeoutMaxRetry) {
+    while (retry <= maxRetry) {
       try {
         return this.client.BatchGetLog(project, logStore, shardId, count, cursor, endCursor);
       } catch (LogException e) {
-        if (isRecoverableException(e)) {
+        if (shouldRetry(e, retry)) {
           retry += 1;
           Thread.sleep(backoff);
           backoff = Math.min(backoff * 2, maxBackoff);
@@ -222,7 +222,7 @@ public class LoghubClientAgent {
         }
       }
     }
-    LOG.error("reconnect to log-service exceed max retry times[" + logServiceTimeoutMaxRetry + "].");
+    LOG.error("reconnect to log-service exceed max retry times[" + maxRetry + "].");
     assert (currentException != null);
     throw currentException;
   }
@@ -232,11 +232,11 @@ public class LoghubClientAgent {
     int retry = 0;
     Exception currentException = null;
     long backoff = initialBackoff;
-    while (retry <= logServiceTimeoutMaxRetry) {
+    while (retry <= maxRetry) {
       try {
         return this.client.GetHistograms(project, logStore, from, to, topic, query);
       } catch (LogException e) {
-        if (isRecoverableException(e)) {
+        if (shouldRetry(e, retry)) {
           retry += 1;
           Thread.sleep(backoff);
           backoff = Math.min(backoff * 2, maxBackoff);
@@ -249,7 +249,7 @@ public class LoghubClientAgent {
         }
       }
     }
-    LOG.error("reconnect to log-service exceed max retry times[" + logServiceTimeoutMaxRetry + "].");
+    LOG.error("reconnect to log-service exceed max retry times[" + maxRetry + "].");
     assert (currentException != null);
     throw currentException;
   }
@@ -259,11 +259,11 @@ public class LoghubClientAgent {
     int retry = 0;
     Exception currentException = null;
     long backoff = initialBackoff;
-    while (retry <= logServiceTimeoutMaxRetry) {
+    while (retry <= maxRetry) {
       try {
         return this.client.GetCursorTime(project, logStore, shardId, cursor);
       } catch (LogException e) {
-        if (isRecoverableException(e)) {
+        if (shouldRetry(e, retry)) {
           retry += 1;
           Thread.sleep(backoff);
           backoff = Math.min(backoff * 2, maxBackoff);
@@ -273,7 +273,7 @@ public class LoghubClientAgent {
         }
       }
     }
-    LOG.error("reconnect to log-service exceed max retry times[" + logServiceTimeoutMaxRetry + "].");
+    LOG.error("reconnect to log-service exceed max retry times[" + maxRetry + "].");
     assert (currentException != null);
     throw currentException;
   }
@@ -286,5 +286,9 @@ public class LoghubClientAgent {
 
   private static boolean isRecoverableException(LogException ex) {
     return checkConnectionTimeoutException(ex) || ex.GetHttpCode() >= 500;
+  }
+
+  private boolean shouldRetry(LogException ex, int retry) {
+    return isRecoverableException(ex) && retry < maxRetry;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <oss.sdk.version>3.0.0</oss.sdk.version>
         <tablestore.sdk.version>4.4.0</tablestore.sdk.version>
         <odps.version>0.28.4-public</odps.version>
-        <loghubb.client.version>0.6.16</loghubb.client.version>
+        <loghubb.client.version>0.6.15</loghubb.client.version>
         <aliyun.log.version>0.6.31</aliyun.log.version>
         <aliyun.log.producer.version>0.2.0</aliyun.log.producer.version>
         <ons.version>1.7.1.Final</ons.version>


### PR DESCRIPTION
Currently, we didn't do anything for possible temporary internal server error  when accessing Loghub API. However, there are a lot of situations can cause internal server error, such as add a new shard. Or create a new consumer group. This pull request try to add some retries for those situations. And also, the library loghub-client-lib:0.6.16 has some break changes, we need to revert to 0.6.16 until we decide to migrate. 