### PR TITLE
Fix gson producing different date formats in diferent os/locale.

### DIFF
--- a/emr-oss/src/main/java/com/aliyun/fs/oss/utils/OSSClientAgent.java
+++ b/emr-oss/src/main/java/com/aliyun/fs/oss/utils/OSSClientAgent.java
@@ -213,7 +213,7 @@ public class OSSClientAgent {
       GsonBuilder builder = new GsonBuilder();
       builder.registerTypeAdapter(ObjectMetadata.class,
           new ObjectMetadataDeserializer());
-      Gson gson = builder.create();
+      Gson gson = builder.setDateFormat("MMM d, yyyy K:mm:ss a").create();
 
       Method method = this.ossClientClz.getMethod("getObjectMetadata",
           String.class, String.class);

--- a/emr-oss/src/main/java/com/aliyun/fs/oss/utils/OSSClientAgent.java
+++ b/emr-oss/src/main/java/com/aliyun/fs/oss/utils/OSSClientAgent.java
@@ -213,7 +213,7 @@ public class OSSClientAgent {
       GsonBuilder builder = new GsonBuilder();
       builder.registerTypeAdapter(ObjectMetadata.class,
           new ObjectMetadataDeserializer());
-      Gson gson = builder.setDateFormat("MMM d, yyyy, K:mm:ss a").create();
+      Gson gson = builder.setDateFormat("MMM d, yyyy K:mm:ss a").create();
 
       Method method = this.ossClientClz.getMethod("getObjectMetadata",
           String.class, String.class);
@@ -265,7 +265,7 @@ public class OSSClientAgent {
       GsonBuilder builder = new GsonBuilder();
       builder.registerTypeAdapter(ObjectMetadata.class,
           new ObjectMetadataDeserializer());
-      Gson gson = builder.create();
+      Gson gson = builder.setDateFormat("MMM d, yyyy K:mm:ss a").create();
       Method method2 = OSSObjectClz.getMethod("getObjectMetadata");
       Object metadata = method2.invoke(ret);
       ObjectMetadata objectMetadata = gson.fromJson(gson.toJson(metadata),
@@ -784,7 +784,7 @@ public class OSSClientAgent {
   private static class ObjectMetadataDeserializer
       implements JsonDeserializer<ObjectMetadata> {
     private DateFormat df =
-        new SimpleDateFormat("MMM d, yyyy, K:mm:ss a", Locale.ENGLISH);
+        new SimpleDateFormat("MMM d, yyyy K:mm:ss a", Locale.ENGLISH);
 
     public ObjectMetadata deserialize(JsonElement json, Type typeOfT,
         JsonDeserializationContext context) {

--- a/emr-oss/src/main/java/com/aliyun/fs/oss/utils/OSSClientAgent.java
+++ b/emr-oss/src/main/java/com/aliyun/fs/oss/utils/OSSClientAgent.java
@@ -213,7 +213,7 @@ public class OSSClientAgent {
       GsonBuilder builder = new GsonBuilder();
       builder.registerTypeAdapter(ObjectMetadata.class,
           new ObjectMetadataDeserializer());
-      Gson gson = builder.setDateFormat("MMM d, yyyy K:mm:ss a").create();
+      Gson gson = builder.setDateFormat("MMM d, yyyy, K:mm:ss a").create();
 
       Method method = this.ossClientClz.getMethod("getObjectMetadata",
           String.class, String.class);

--- a/emr-oss/src/main/java/com/aliyun/fs/oss/utils/OSSClientAgent.java
+++ b/emr-oss/src/main/java/com/aliyun/fs/oss/utils/OSSClientAgent.java
@@ -784,7 +784,7 @@ public class OSSClientAgent {
   private static class ObjectMetadataDeserializer
       implements JsonDeserializer<ObjectMetadata> {
     private DateFormat df =
-        new SimpleDateFormat("MMM d, yyyy K:mm:ss a", Locale.ENGLISH);
+        new SimpleDateFormat("MMM d, yyyy, K:mm:ss a", Locale.ENGLISH);
 
     public ObjectMetadata deserialize(JsonElement json, Type typeOfT,
         JsonDeserializationContext context) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previous PR #349 simply fixed bug #347 for windows environment. The root cause of the problem is that gson, by default (probably  due to different os environment/locale which I did not have time to investigate), generates different datetime formats. A small example showing that:

![image](https://user-images.githubusercontent.com/1296736/63260619-00830880-c2b4-11e9-9f96-9fc7c8eb3019.png)

![image](https://user-images.githubusercontent.com/1296736/63260584-ea754800-c2b3-11e9-8469-8c1b0e6ffe67.png)

The fix is to set the date format explicitly to make it more deterministic.

## How was this patch tested?

Tested manually in two different os environments (windows 7 & Ubuntu 18.04.1 LTS).

