### PR TITLE
Do not retry if consumer group already exist

### DIFF
--- a/emr-logservice/src/main/java/org/apache/spark/streaming/aliyun/logservice/RetryUtil.java
+++ b/emr-logservice/src/main/java/org/apache/spark/streaming/aliyun/logservice/RetryUtil.java
@@ -37,6 +37,9 @@ final class RetryUtil {
       try {
         return callable.call();
       } catch (LogException ex) {
+        if ("ConsumerGroupAlreadyExist".equals(ex.GetErrorCode())) {
+          throw ex;
+        }
         if (ex.GetHttpCode() < 500) {
           if (retries >= maxRetry) {
             LOG.error("reconnect to log-service exceed max retry times[" + maxRetry + "].");


### PR DESCRIPTION
No need to retry if consumer group already exist when creating consumer group.