### PR TITLE
Remove explicit calls to System.gc()

### DIFF
--- a/emr-oss/src/main/java/com/aliyun/fs/oss/nat/BufferReader.java
+++ b/emr-oss/src/main/java/com/aliyun/fs/oss/nat/BufferReader.java
@@ -138,7 +138,6 @@ public class BufferReader {
     } catch (IOException e) {
       LOG.error("Failed to close input stream.", e);
     } finally {
-      System.gc();
       buffer = null;
     }
   }


### PR DESCRIPTION
Manually calling this method causes Spark to take up too much GC time for OSS. It is recommended to remove the method call.

## What changes were proposed in this pull request?

Reduce Full GC frequency and reduce the time required for GC.

## How was this patch tested?

Using -XX:+DisableExplicitGC simulates the removal of this line of code and found no problems.
