### PR TITLE
Tablestore Source: modify validateOptions

### DIFF
--- a/emr-tablestore/src/main/scala/org/apache/spark/sql/aliyun/tablestore/TableStoreSourceProvider.scala
+++ b/emr-tablestore/src/main/scala/org/apache/spark/sql/aliyun/tablestore/TableStoreSourceProvider.scala
@@ -58,7 +58,7 @@ class TableStoreSourceProvider
       schema: Option[StructType],
       providerName: String,
       parameters: Map[String, String]): Source = {
-    validateOptions(parameters)
+    validateOptions(parameters, true)
     val caseInsensitiveParams = parameters.map {
       case (k, v) => (k.toLowerCase(Locale.ROOT), v)
     }
@@ -75,11 +75,11 @@ class TableStoreSourceProvider
   override def createRelation(
       sqlContext: SQLContext,
       parameters: Map[String, String]): BaseRelation = {
-    validateOptions(parameters)
+    validateOptions(parameters, false)
     new TableStoreRelation(parameters, Some(TableStoreCatalog(parameters).schema))(sqlContext)
   }
 
-  def validateOptions(caseInsensitiveParams: Map[String, String]): Unit = {
+  def validateOptions(caseInsensitiveParams: Map[String, String], isStream: Boolean): Unit = {
     caseInsensitiveParams.getOrElse(
       "table.name",
       throw new MissingArgumentException("Missing TableStore table (='table.name').")
@@ -88,10 +88,12 @@ class TableStoreSourceProvider
       "instance.name",
       throw new MissingArgumentException("Missing TableStore table (='instance.name').")
     )
-    caseInsensitiveParams.getOrElse(
-      "tunnel.id",
-      throw new MissingArgumentException("Missing TableStore tunnel (='tunnel.id').")
-    )
+    if (isStream) {
+      caseInsensitiveParams.getOrElse(
+        "tunnel.id",
+        throw new MissingArgumentException("Missing TableStore tunnel (='tunnel.id').")
+      )
+    }
     caseInsensitiveParams.getOrElse(
       "access.key.id",
       throw new MissingArgumentException("Missing access key id (='access.key.id').")

--- a/emr-tablestore/src/main/scala/org/apache/spark/sql/aliyun/tablestore/TableStoreSourceProvider.scala
+++ b/emr-tablestore/src/main/scala/org/apache/spark/sql/aliyun/tablestore/TableStoreSourceProvider.scala
@@ -58,7 +58,7 @@ class TableStoreSourceProvider
       schema: Option[StructType],
       providerName: String,
       parameters: Map[String, String]): Source = {
-    validateOptions(parameters, true)
+    validateOptions(parameters, isStream = true)
     val caseInsensitiveParams = parameters.map {
       case (k, v) => (k.toLowerCase(Locale.ROOT), v)
     }
@@ -75,7 +75,7 @@ class TableStoreSourceProvider
   override def createRelation(
       sqlContext: SQLContext,
       parameters: Map[String, String]): BaseRelation = {
-    validateOptions(parameters, false)
+    validateOptions(parameters, isStream = false)
     new TableStoreRelation(parameters, Some(TableStoreCatalog(parameters).schema))(sqlContext)
   }
 

--- a/emr-tablestore/src/test/scala/org/apache/spark/sql/aliyun/tablestore/TableStoreSourceProviderSuite.scala
+++ b/emr-tablestore/src/test/scala/org/apache/spark/sql/aliyun/tablestore/TableStoreSourceProviderSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.aliyun.tablestore
+
+import org.apache.commons.cli.MissingArgumentException
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.SparkSession
+
+
+class TableStoreSourceProviderSuite extends SparkFunSuite {
+  private val testUtils = new TableStoreTestUtil()
+
+  test("validate full data options") {
+    val spark = SparkSession.builder
+      .appName("TestValidateOptions")
+      .master("local[1]")
+      .getOrCreate()
+    try {
+      testUtils.createTestRelation(spark.sqlContext, Map("catalog" -> TableStoreTestUtil.catalog))
+    } catch {
+      // should not achieve here.
+      case ex: Throwable => fail(ex)
+    }
+  }
+
+  test("validate stream options without tunnelId") {
+    val spark = SparkSession.builder
+      .appName("TestValidateOptions")
+      .master("local[1]")
+      .getOrCreate()
+
+    try {
+      testUtils.createTestSource(spark.sqlContext, Map("catalog" -> TableStoreTestUtil.catalog))
+    } catch {
+      case ex: MissingArgumentException => succeed
+      case ex: Throwable => fail(ex)
+    }
+  }
+
+  test("validate stream options") {
+    val spark = SparkSession.builder
+      .appName("TestValidateOptions")
+      .master("local[1]")
+      .getOrCreate()
+
+    try {
+      testUtils.createTestSource(spark.sqlContext, Map(
+        "catalog" -> TableStoreTestUtil.catalog, "tunnel.id" -> "testTunnelId"))
+    } catch {
+      case ex: Throwable => print(ex)
+    }
+  }
+
+}


### PR DESCRIPTION
批量的Source里面，不需要再验证tunnel.id了，要不然建批量表的时候都需要传一个tunnel.id， 做一些处理。
12月9号：增加一些UT
![image](https://user-images.githubusercontent.com/9008525/70419924-7ac4dc00-1aa1-11ea-9c48-656dea49e900.png)


