### PR TITLE
Fix writing data to loghub NPE

### DIFF
--- a/emr-logservice/src/main/scala/org/apache/spark/sql/aliyun/logservice/Utils.scala
+++ b/emr-logservice/src/main/scala/org/apache/spark/sql/aliyun/logservice/Utils.scala
@@ -88,8 +88,9 @@ object Utils extends Logging {
 
             while (convertersIterator.hasNext) {
               val converter = convertersIterator.next()
-              val logContent =
-                new LogContent(fieldNamesIterator.next(), converter(rowIterator.next()).toString)
+	      val logContent =
+                new LogContent(fieldNamesIterator.next(),
+                  converter(Option(rowIterator.next()).getOrElse("")).toString)
               record.PushBack(logContent)
             }
             record


### PR DESCRIPTION
## When using EMR logservice version 1.9.0, a NullPointerException will occur when writing data to loghub (SLS)

```
19/12/18 16:43:14 ERROR Executor: Exception in task 0.0 in stage 0.0 (TID 0)
java.lang.NullPointerException
	at org.apache.spark.sql.aliyun.logservice.Utils$$anonfun$toConverter$5.apply(Utils.scala:92)
	at org.apache.spark.sql.aliyun.logservice.LoghubGroupWriter.sendRow(LoghubWriterTask.scala:84)
	at org.apache.spark.sql.aliyun.logservice.LoghubWriterTask.execute(LoghubWriterTask.scala:48)
```

Spark dataframe writes data in logstore to loghub (SLS) when the value of a column is null，Can reproduce this problem.

Because null value is not judged in the code. The tostring method was called in the presence of a null value.

## How to fix 

Using the `Option` in scala with the `getOrElse` method, when null value occurs, give a default value to fix this problem.
