### PR TITLE
[EMR-SDK] add Datahub writer

### DIFF
--- a/emr-datahub/pom.xml
+++ b/emr-datahub/pom.xml
@@ -144,6 +144,10 @@
                             <pattern>okio</pattern>
                             <shadedPattern>${emr.shade.packageName}.okio</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>retrofit2</pattern>
+                            <shadedPattern>${emr.shade.packageName}.retrofit2</shadedPattern>
+                        </relocation>
                     </relocations>
                 </configuration>
                 <executions>

--- a/emr-datahub/pom.xml
+++ b/emr-datahub/pom.xml
@@ -144,10 +144,6 @@
                             <pattern>okio</pattern>
                             <shadedPattern>${emr.shade.packageName}.okio</shadedPattern>
                         </relocation>
-                        <relocation>
-                            <pattern>retrofit2</pattern>
-                            <shadedPattern>${emr.shade.packageName}.retrofit2</shadedPattern>
-                        </relocation>
                     </relocations>
                 </configuration>
                 <executions>

--- a/emr-datahub/src/main/scala/org/apache/spark/sql/aliyun/datahub/DatahubAsyncDataWriter.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/sql/aliyun/datahub/DatahubAsyncDataWriter.scala
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.aliyun.datahub
+
+import java.{util => ju}
+import java.util.concurrent.locks.ReentrantLock
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+import collection.mutable._
+import com.aliyun.datahub.client.DatahubClient
+import com.aliyun.datahub.client.exception.DatahubClientException
+import com.aliyun.datahub.client.model._
+
+
+class DatahubAsyncDataWriter(
+  client: DatahubClient,
+  project: String,
+  topic: String,
+  batchSize: Int,
+  batchNum: Int) {
+
+  final val RECORDS_SIZE_PER_BATCH: Int = batchSize
+  final val flushInterval: Long = 10000L  // 10 seconds
+
+  // for the Future Queue
+  final val BATCH_NUM = batchNum
+  final val futureLock = new ReentrantLock
+  final val notFull = futureLock.newCondition
+  final val notEmpty = futureLock.newCondition
+  val futuresQueue = new ju.ArrayList[Future[PutRecordsResult]]()
+
+  // for the PutRecordsResult Queue
+  val resultLock = new ReentrantLock
+  val resultQueue = new ju.ArrayList[PutRecordsResult]()
+  @volatile var failedWrite: Exception = _
+
+  // batch buffer
+  val buffer = new ju.concurrent.LinkedBlockingDeque[RecordEntry](RECORDS_SIZE_PER_BATCH)
+  var lastWrite = System.currentTimeMillis
+
+  startTimerFlush()
+
+  def putRecord(record: RecordEntry): Unit = {
+    buffer.put(record)
+    if (buffer.size() >= RECORDS_SIZE_PER_BATCH) {
+      sendBatch()
+    }
+  }
+
+  def flush(): Unit = {
+    if (buffer.size() >= 0) {
+      sendBatch()
+    }
+  }
+
+  def checkStatus(): Unit = {
+    if (failedWrite != null) {
+      return
+    }
+
+    resultLock.lockInterruptibly()
+
+    resultQueue.asScala.foreach({ res =>
+      if (res.getFailedRecordCount > 0) {
+        var errList = new ListBuffer[String]()
+        res.getPutErrorEntries.asScala.foreach(err => {
+          errList += ("ErrCode:" + err.getErrorcode
+            + "Index:" + err.getIndex
+            + "ErrMsg" + err.getMessage)
+        })
+        failedWrite = new DatahubClientException(errList.mkString(""))
+      }
+    })
+
+    resultLock.unlock()
+  }
+
+  def waitCompleted(): Unit = {
+    futureLock.lockInterruptibly()
+    try {
+      while ( {
+        futuresQueue.size > 0
+      }) notFull.await()
+    } finally {
+      futureLock.unlock()
+    }
+  }
+
+  private def sendBatch(): Unit = {
+    val records = new ju.ArrayList[RecordEntry]()
+    buffer.drainTo(records)
+    if (records.size() == 0) {
+      return
+    }
+    val f = asyncPutRecordsPack(records)
+    putFuture(f)
+    f.onComplete {
+      case Success(result) =>
+        removeFuture(f)
+        putResult(result)
+      case Failure(e) =>
+        removeFuture(f)
+        failedWrite = new Exception(e.getMessage)
+    }
+  }
+
+  private def asyncPutRecordsPack(records: ju.ArrayList[RecordEntry])
+              : Future[PutRecordsResult] = Future {
+    lastWrite = System.currentTimeMillis
+    client.putRecords(project, topic, records)
+  }
+
+  private def putResult(r: PutRecordsResult) = {
+    resultLock.lock()
+    resultQueue.add(r)
+    resultLock.unlock()
+  }
+
+  private def putFuture(f: Future[PutRecordsResult]) = {
+    futureLock.lockInterruptibly()
+    try {
+      while ( {
+        futuresQueue.size >= BATCH_NUM
+      }) notFull.await()
+
+      futuresQueue.add(f)
+      notEmpty.signal()
+    } finally {
+      futureLock.unlock()
+    }
+  }
+
+  private def removeFuture(f: Future[PutRecordsResult]) = {
+    futureLock.lockInterruptibly()
+    try {
+      futuresQueue.remove(f)
+      notFull.signalAll()
+    } finally {
+      futureLock.unlock()
+    }
+  }
+
+  private def startTimerFlush(): Unit = {
+    val flusher = new ju.Timer("datahub.buffer.timer.flusher")
+    flusher.schedule(new ju.TimerTask() {
+      override def run(): Unit = {
+        if ((System.currentTimeMillis - lastWrite > flushInterval) && buffer.size() > 0) {
+          flush()
+        }
+      }
+    }, flushInterval, flushInterval)
+  }
+}

--- a/emr-datahub/src/main/scala/org/apache/spark/sql/aliyun/datahub/DatahubDataWriter.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/sql/aliyun/datahub/DatahubDataWriter.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.aliyun.datahub
+
+import com.aliyun.datahub.client.DatahubClient
+import com.aliyun.datahub.client.exception._
+import com.aliyun.datahub.client.model._
+import scala.collection._
+import scala.collection.JavaConverters._
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.sources.v2.writer.{DataWriter, WriterCommitMessage}
+import org.apache.spark.sql.types._
+
+
+// One Spark task has one exclusive data writer, so there is no thread-safe concern.
+class DatahubDataWriter(
+    project: Option[String],
+    topic: Option[String],
+    sourceOptions: immutable.Map[String, String],
+    schema: Option[StructType]) extends DataWriter[InternalRow] with Logging {
+
+  private val client = DatahubSourceProvider.getOrCreateDatahubClientV2(sourceOptions)
+
+  lazy val getRecordResult = client.getTopic(project.get, topic.get)
+  lazy val recordSchema: RecordSchema = getRecordResult.getRecordSchema
+
+  lazy val asyncWriter: DatahubAsyncDataWriter =
+    getAsyncWriter(client, project.get, topic.get, sourceOptions)
+
+  override def commit(): WriterCommitMessage = {
+    checkError()
+    asyncWriter.flush()
+    asyncWriter.waitCompleted()
+    checkError()
+
+    DatahubWriterCommitMessage
+  }
+
+  override def abort(): Unit = {
+  }
+
+  override def write(row: InternalRow): Unit = {
+    try {
+      val recordEntry = convertRowToRecordEntry(row)
+      checkError()
+      asyncWriter.putRecord(recordEntry)
+    } catch {
+      case ex: Exception =>
+        logError(ex.getMessage)
+        throw ex
+    }
+  }
+
+  private def checkError(): Unit = {
+    asyncWriter.checkStatus()
+
+    if (asyncWriter.failedWrite != null) {
+      asyncWriter.failedWrite match {
+        case e: InvalidParameterException =>
+          logError("Invalid parameter, please check your parameter." + e.getErrorMessage)
+          throw e
+        case e: AuthorizationFailureException =>
+          logError("AK error, please check your accessId and accessKey" + e.getErrorMessage)
+          throw e
+        case e: ResourceNotFoundException =>
+          logError("project or topic or shard is not found" + e.getErrorMessage)
+          throw e
+        case e: ShardSealedException =>
+          logError("shard status is CLOSED, can not be writen" + e.getErrorMessage)
+          throw e
+        case e: DatahubClientException =>
+          logError(e.getErrorMessage)
+          throw e
+      }
+    }
+  }
+
+  private def convertRowToRecordEntry(row: InternalRow): RecordEntry = {
+
+    val record: RecordEntry = new RecordEntry()
+    val data: RecordData = getRecordResult.getRecordType match {
+      case RecordType.BLOB => new BlobRecordData(row.getString(0).getBytes("UTF-8"))
+      case RecordType.TUPLE =>
+        val tuple = new TupleRecordData(recordSchema)
+        var idx = 0
+        recordSchema.getFields.asScala.foreach(field => {
+          field.getType match {
+            case FieldType.BIGINT => tuple.setField(idx, row.getLong(idx))
+            case FieldType.TIMESTAMP => tuple.setField(idx, row.getLong(idx))
+            case FieldType.BOOLEAN => tuple.setField(idx, row.getBoolean(idx))
+            case FieldType.DECIMAL =>
+              // TODO: open issue, get precision & scale
+              tuple.setField(idx, row.getDecimal(idx, 38, 18).toJavaBigDecimal)
+            case FieldType.DOUBLE => tuple.setField(idx, row.getDouble(idx))
+            case _ => tuple.setField(idx, row.getString(idx))
+          }
+          idx = idx + 1
+        })
+        tuple
+    }
+
+    record.setRecordData(data)
+    record
+  }
+
+  private def getAsyncWriter(
+    client: DatahubClient,
+    project: String,
+    topic: String,
+    sourceOptions: immutable.Map[String, String]): DatahubAsyncDataWriter = {
+
+    val batchSize = sourceOptions.get(DatahubSourceProvider.OPTION_KEY_BATCH_SIZE).map(_.trim.toInt)
+    val batchNum = sourceOptions.get(DatahubSourceProvider.OPTION_KEY_BATCH_NUM).map(_.trim.toInt)
+
+    // by default, no batch
+    val size = batchSize.getOrElse(1)
+
+    // Future numbers
+    val num = batchNum.getOrElse(5)
+
+    new DatahubAsyncDataWriter(client, project, topic, size, num)
+  }
+}
+

--- a/emr-datahub/src/main/scala/org/apache/spark/sql/aliyun/datahub/DatahubDataWriter.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/sql/aliyun/datahub/DatahubDataWriter.scala
@@ -41,6 +41,9 @@ class DatahubDataWriter(
   lazy val getRecordResult = client.getTopic(project.get, topic.get)
   lazy val recordSchema: RecordSchema = getRecordResult.getRecordSchema
 
+  private lazy val precision = sourceOptions("decimal.precision").toInt
+  private lazy val scale = sourceOptions("decimal.scale").toInt
+
   lazy val asyncWriter: DatahubAsyncDataWriter =
     getAsyncWriter(client, project.get, topic.get, sourceOptions)
 
@@ -106,8 +109,7 @@ class DatahubDataWriter(
             case FieldType.TIMESTAMP => tuple.setField(idx, row.getLong(idx))
             case FieldType.BOOLEAN => tuple.setField(idx, row.getBoolean(idx))
             case FieldType.DECIMAL =>
-              // TODO: open issue, get precision & scale
-              tuple.setField(idx, row.getDecimal(idx, 38, 18).toJavaBigDecimal)
+              tuple.setField(idx, row.getDecimal(idx, precision, scale).toJavaBigDecimal)
             case FieldType.DOUBLE => tuple.setField(idx, row.getDouble(idx))
             case _ => tuple.setField(idx, row.getString(idx))
           }

--- a/emr-datahub/src/main/scala/org/apache/spark/sql/aliyun/datahub/DatahubWriter.scala
+++ b/emr-datahub/src/main/scala/org/apache/spark/sql/aliyun/datahub/DatahubWriter.scala
@@ -18,25 +18,27 @@
 package org.apache.spark.sql.aliyun.datahub
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.sources.v2.writer.{DataWriter, DataWriterFactory, WriterCommitMessage}
-import org.apache.spark.sql.sources.v2.writer.streaming.StreamWriter
+import org.apache.spark.sql.sources.v2.writer.{DataSourceWriter, DataWriter, DataWriterFactory, WriterCommitMessage}
 import org.apache.spark.sql.types.StructType
 
-class DatahubStreamWriter(
+class DatahubWriter(
     project: Option[String],
     topic: Option[String],
     datahubOptions: Map[String, String],
-    schema: Option[StructType]) extends StreamWriter {
-  override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
+    schema: Option[StructType]) extends DataSourceWriter {
 
-  override def abort(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
+  override def commit(messages: Array[WriterCommitMessage]): Unit = {
+  }
 
-  override def createWriterFactory(): DatahubStreamWriterFactory = {
-    DatahubStreamWriterFactory(project, topic, datahubOptions, schema)
+  override def abort(messages: Array[WriterCommitMessage]): Unit = {
+  }
+
+  override def createWriterFactory(): DatahubWriterFactory = {
+    DatahubWriterFactory(project, topic, datahubOptions, schema)
   }
 }
 
-case class DatahubStreamWriterFactory(
+case class DatahubWriterFactory(
     project: Option[String],
     topic: Option[String],
     datahubParams: Map[String, String],
@@ -49,12 +51,3 @@ case class DatahubStreamWriterFactory(
     new DatahubDataWriter(project, topic, datahubParams, schema)
   }
 }
-
-class DatahubStreamDataWriter(
-    project: Option[String],
-    topic: Option[String],
-    datahubParams: Map[String, String],
-    schema: Option[StructType]) extends DatahubDataWriter(project, topic, datahubParams, schema) {
-}
-
-case object DatahubWriterCommitMessage extends WriterCommitMessage

--- a/emr-datahub/src/test/scala/org/apache/spark/sql/aliyun/datahub/DatahubSinkSuite.scala
+++ b/emr-datahub/src/test/scala/org/apache/spark/sql/aliyun/datahub/DatahubSinkSuite.scala
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.aliyun.datahub
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.spark.sql.execution.streaming.sources.ContinuousMemoryStream
+import org.apache.spark.sql.execution.streaming.{MemoryStream, StreamingExecutionRelation}
+import org.apache.spark.sql.streaming.{OutputMode, Trigger}
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
+
+
+abstract class DatahubSinkSuite extends QueryTest with SharedSparkSession {
+
+  protected var testUtils: DatahubTestUtils = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    testUtils = new DatahubTestUtils()
+    testUtils.init()
+  }
+
+  override def afterAll(): Unit = {
+    // testUtils.cleanAllResource()
+  }
+
+  protected def createDatahubReader(project: String, topic: String): DataFrame = {
+    spark.readStream
+      .format("datahub")
+      .option(DatahubSourceProvider.OPTION_KEY_ACCESS_ID, testUtils.accessKeyId)
+      .option(DatahubSourceProvider.OPTION_KEY_ACCESS_KEY, testUtils.accessKeySecret)
+      .option(DatahubSourceProvider.OPTION_KEY_ENDPOINT, testUtils.endpoint)
+      .option(DatahubSourceProvider.OPTION_KEY_PROJECT, testUtils.project)
+      .option(DatahubSourceProvider.OPTION_KEY_TOPIC, topic)
+      .load()
+  }
+
+  val defaultSchema = StructType(Array(StructField("id", LongType), StructField("msg", StringType)))
+}
+
+class DatahubSinkBatchSuiteBase extends DatahubSinkSuite {
+  test (" simple batch write to datahub") {
+    val topic = Option(System.getenv("DATAHUB_TOPIC")).getOrElse {
+      testUtils.createTopic(defaultSchema)
+    }
+    val data = Seq(
+      Row(1L, "hello spark batch"),  // .getBytes(UTF_8)
+      Row(2L, "hello datahub"),
+      Row(3L, "emr")
+    )
+
+    val df = spark.createDataFrame(
+      spark.sparkContext.parallelize(data),
+      defaultSchema
+    )
+
+    df.write
+      .format("datahub")
+      .option(DatahubSourceProvider.OPTION_KEY_ACCESS_ID, testUtils.accessKeyId)
+      .option(DatahubSourceProvider.OPTION_KEY_ACCESS_KEY, testUtils.accessKeySecret)
+      .option(DatahubSourceProvider.OPTION_KEY_ENDPOINT, testUtils.endpoint)
+      .option(DatahubSourceProvider.OPTION_KEY_PROJECT, testUtils.project)
+      .option(DatahubSourceProvider.OPTION_KEY_TOPIC, topic)
+      .mode("append")
+      .save()
+  }
+
+}
+
+class DatahubSinkStreamingSuiteBase extends DatahubSinkSuite {
+}
+
+class DatahubSinkMicroBatchStreamingSuite extends DatahubSinkStreamingSuiteBase {
+  import testImplicits._
+  ignore("microbatch -default") {
+    val topic = testUtils.createTopic(defaultSchema)
+    val input = MemoryStream[(Long, String)]
+    input.toDF().select($"_1" as "id", $"_2" as "msg")
+
+    val query = input
+      .toDF()
+      .select($"_1" as "id", $"_2" as "msg")
+      .writeStream
+//      .format("console").start()
+      .format("datahub")
+      .option(DatahubSourceProvider.OPTION_KEY_ACCESS_ID, testUtils.accessKeyId)
+      .option(DatahubSourceProvider.OPTION_KEY_ACCESS_KEY, testUtils.accessKeySecret)
+      .option(DatahubSourceProvider.OPTION_KEY_ENDPOINT, testUtils.endpoint)
+      .option(DatahubSourceProvider.OPTION_KEY_PROJECT, testUtils.project)
+      .option(DatahubSourceProvider.OPTION_KEY_TOPIC, topic)
+      .option("checkpointLocation", "/tmp/spark/checkpoint")
+      .start()
+
+    try {
+      input.addData((1, "msg1"), (2, "msg2"), (3, "msg3"))
+      query.processAllAvailable()
+      input.addData((4, "msg4"), (5, "msg5"), (6, "msg6"))
+      query.processAllAvailable()
+      input.addData()
+      query.processAllAvailable()
+    } finally {
+      query.stop()
+    }
+  }
+}
+
+class DatahubContinuousSinkSuite extends DatahubSinkStreamingSuiteBase {
+  import testImplicits._
+  test("continuous - default") {
+    // val topic = testUtils.createTopic(defaultSchema)
+    val input = spark.readStream
+      .format("rate")
+      .option("numPartitions", "1")
+      .option("rowsPerSecond", "5")
+      .load()
+      .select('value)
+
+    val query = input
+      .writeStream
+//      .format("console")
+      .format("datahub")
+      .option(DatahubSourceProvider.OPTION_KEY_ACCESS_ID, testUtils.accessKeyId)
+      .option(DatahubSourceProvider.OPTION_KEY_ACCESS_KEY, testUtils.accessKeySecret)
+      .option(DatahubSourceProvider.OPTION_KEY_ENDPOINT, testUtils.endpoint)
+      .option(DatahubSourceProvider.OPTION_KEY_PROJECT, testUtils.project)
+      .option(DatahubSourceProvider.OPTION_KEY_TOPIC, "topic_emr_1")
+      .option("checkpointLocation", "/tmp/spark/checkpoint")
+      .trigger(Trigger.Continuous(200)).start()
+    assert(query.isActive)
+    query.stop()
+  }
+
+}

--- a/emr-datahub/src/test/scala/org/apache/spark/sql/aliyun/datahub/DatahubTestUtils.scala
+++ b/emr-datahub/src/test/scala/org/apache/spark/sql/aliyun/datahub/DatahubTestUtils.scala
@@ -45,9 +45,11 @@ class DatahubTestUtils {
     throw new Exception(s"Unsupported test environment type: $envType, only support private or public")
   }
 
-  val endpoint: String = envType match {
-    case "private" => s"http://dh-$region.aliyun-inc.com"
-    case "public" => s"https://dh-$region.aliyuncs.com"
+  val endpoint: String = Option(System.getenv("DATAHUB_ENDPOINT")).getOrElse {
+    envType match {
+      case "private" => s"http://dh-$region.aliyun-inc.com"
+      case "public" => s"https://dh-$region.aliyuncs.com"
+    }
   }
 
   private def newTopic(): String = s"topic_for_emr_sdk_ut_${id.incrementAndGet()}"


### PR DESCRIPTION
            ## What changes were proposed in this pull request?

            Spark can write data to Datahub sink.

            Here are some options:
            * "batch.size":
              To improve performance, datahub writer will try to pack records in a pack,
              and send them to Datahub in a requset. Note that, "1" is the default value. It means that
              the write will send record to datahub one by one, by default.

            * "retry": How many times the client will try after put records
               to Datahub failed.

            ```scala
             df.write
              .format("datahub")
              .option("access.key.id", "yourAccessKeyId")
              .option(, "yourAccessKeySecret")
              .option(DatahubSourceProvider.OPTION_KEY_ENDPOINT, "datahubEndpoint")
              .option(DatahubSourceProvider.OPTION_KEY_PROJECT, "yourProject")
              .option(DatahubSourceProvider.OPTION_KEY_TOPIC, "yourTopic")
              .option(DatahubSourceProvider.OPTION_KEY_BATCH_SIZE, "100")
              .option(DatahubSourceProvider.OPTION_KEY_RETRIES, "3")
              .mode("append")
              .save()

            ```
            ## How was this patch tested?
            N/A

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(Refer to this [test guide](https://github.com/aliyun/aliyun-emapreduce-sdk/blob/master-2.x/docs/how_to_run_tests.md))
